### PR TITLE
Use multitenancy if no SCRIVITO_TENANT defined

### DIFF
--- a/src/config/scrivito.ts
+++ b/src/config/scrivito.ts
@@ -1,12 +1,22 @@
 import * as Scrivito from 'scrivito'
 
 export function configureScrivito() {
-  const config = {
+  const config: Parameters<typeof Scrivito.configure>[0] = {
     adoptUi: true,
     optimizedWidgetLoading: true,
     strictSearchOperators: true,
     contentTagsForEmptyAttributes: false,
-    tenant: 'd0a154d76edf2a7bd991fc658e700a1d',
+    tenant: import.meta.env.SCRIVITO_TENANT || '',
+  }
+
+  if (!import.meta.env.SCRIVITO_TENANT) {
+    // Multitenancy mode
+    const tenantFromUrl =
+      window.location.pathname.match(/^\/([0-9a-f]{32})\b/)?.[1]
+    if (!tenantFromUrl) throw new Error('Could not determine tenant!')
+
+    config.tenant = tenantFromUrl
+    config.routingBasePath = `/${tenantFromUrl}`
   }
 
   Scrivito.configure(config)

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,5 +1,5 @@
 import dns from 'dns'
-import { defineConfig } from 'vite'
+import { defineConfig, loadEnv } from 'vite'
 import react from '@vitejs/plugin-react-swc'
 import { resolve } from 'path'
 
@@ -8,18 +8,25 @@ import { resolve } from 'path'
 dns.setDefaultResultOrder('verbatim')
 
 // https://vitejs.dev/config/
-export default defineConfig({
-  build: {
-    rollupOptions: {
-      input: {
-        main: resolve(__dirname, 'index.html'),
-        _scrivito_extensions: resolve(__dirname, '_scrivito_extensions.html'),
+export default defineConfig(({ command, mode }) => {
+  const env = loadEnv(mode, process.cwd(), '')
+
+  return {
+    build: {
+      rollupOptions: {
+        input: {
+          main: resolve(__dirname, 'index.html'),
+          _scrivito_extensions: resolve(__dirname, '_scrivito_extensions.html'),
+        },
       },
     },
-  },
-  plugins: [react()],
-  server: {
-    port: 8080,
-    strictPort: true,
-  },
+    define: {
+      'import.meta.env.SCRIVITO_TENANT': JSON.stringify(env.SCRIVITO_TENANT),
+    },
+    plugins: [react()],
+    server: {
+      port: 8080,
+      strictPort: true,
+    },
+  }
 })


### PR DESCRIPTION
To use one specific tenant e.g. locally create a `.env.local` file with the following content:

```
SCRIVITO_TENANT=d0a154d76edf2a7bd991fc658e700a1d
```