### PR TITLE
Bugfix: Load ObjClasses even if they don't have a component

### DIFF
--- a/src/Objs/index.ts
+++ b/src/Objs/index.ts
@@ -1,7 +1,7 @@
 import * as Scrivito from 'scrivito'
 
 import.meta.glob(
-  ['./**/ObjClass.ts', './**/*Component.tsx', './**/*LayoutComponent.tsx'],
+  ['./**/*ObjClass.ts', './**/*Component.tsx', './**/*LayoutComponent.tsx'],
   { eager: true }
 )
 


### PR DESCRIPTION
Discovered during investigation of https://github.com/infopark/scrivito_js/issues/9962.