### PR TITLE
Move the break-point for mobile adoptions to "md" (≥768px)

### DIFF
--- a/src/Objs/SubnavigationOverview/SubnavigationOverviewLayoutComponent.tsx
+++ b/src/Objs/SubnavigationOverview/SubnavigationOverviewLayoutComponent.tsx
@@ -14,11 +14,11 @@ Scrivito.provideLayoutComponent(SubnavigationOverview, ({ page }) => {
       <section className="py-4">
         <div className="container">
           <div className="row">
-            <div className="col-lg-2">
+            <div className="col-md-2">
               <Subnavigation page={page} />
             </div>
 
-            <div className="col-lg-10">
+            <div className="col-md-10">
               <Scrivito.CurrentPage />
             </div>
           </div>

--- a/src/Widgets/ColumnContainerWidget/ColumnContainerWidgetComponent.tsx
+++ b/src/Widgets/ColumnContainerWidget/ColumnContainerWidgetComponent.tsx
@@ -9,7 +9,7 @@ Scrivito.provideComponent(ColumnContainerWidget, ({ widget }) => {
     const colSize = columnWidget.get('colSize') || 1
     const className = widget.get('disableResponsiveAdaption')
       ? `col-${colSize}`
-      : `col-lg-${colSize}`
+      : `col-md-${colSize}`
     return (
       <div key={index} className={className}>
         <Scrivito.ContentTag

--- a/src/Widgets/DataListWidget/DataListWidgetComponent.tsx
+++ b/src/Widgets/DataListWidget/DataListWidgetComponent.tsx
@@ -9,7 +9,7 @@ Scrivito.provideComponent(DataListWidget, ({ widget }) => {
 
   return (
     <>
-      <div className={`row row-cols-1 row-cols-lg-${nrOfColumns}`}>
+      <div className={`row row-cols-1 row-cols-md-${nrOfColumns}`}>
         {/* @ts-expect-error */}
         {dataScope.take().map((order) => (
           <Scrivito.ContentTag

--- a/src/Widgets/NavigationWidget/SubComponents/MainNavigation.tsx
+++ b/src/Widgets/NavigationWidget/SubComponents/MainNavigation.tsx
@@ -9,7 +9,7 @@ export const MainNavigation = Scrivito.connect(function MainNavigation({
   return (
     <div className="navbar-main">
       <Scrivito.ChildListTag
-        className="navbar-nav me-auto mb-2 mb-lg-0"
+        className="navbar-nav me-auto mb-2 mb-md-0"
         tag="div"
         parent={root}
         renderChild={(child) => <NavItem obj={child} />}


### PR DESCRIPTION
Previously it was at "lg" (≥992px) (see https://getbootstrap.com/docs/5.0/layout/grid/ ).

With this change a upright regular tabled would fit in portrait mode. Also a bigger iPhone (e.g. iPhone 12 Pro) would also show the "full size" in landscape mode.