### PR TITLE
[circle] Switch to cimg/node and node 18

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,20 +1,15 @@
 version: 2.1
 
-orbs:
-  node: circleci/node@5.1
-
 jobs:
   execute-npm:
     parameters:
       npm-run-command:
         type: string
     docker:
-      - image: cimg/base:stable
+      - image: cimg/node:18.17
     steps:
       - checkout
-      - node/install:
-          node-version: '16'
-      - node/install-packages
+      - run: npm ci
       - run: npm run << parameters.npm-run-command >>
 
 workflows:


### PR DESCRIPTION
According to https://circleci.com/developer/images/image/cimg/node `circleci/node` is deprecated.

I also tired out caching as described in https://circleci.com/blog/config-best-practices-dependency-caching/ . But the Cache upload/download time took as long as the actual `npm ci`. Since caching also adds more complexity I stayed with a plain `npm ci` instead.