### PR TITLE
Remove duplicate of "data" for "DataListWidgetEditingConfig"

### DIFF
--- a/src/Widgets/DataListWidget/DataListWidgetEditingConfig.ts
+++ b/src/Widgets/DataListWidget/DataListWidgetEditingConfig.ts
@@ -9,7 +9,7 @@ provideEditingConfig(DataListWidget, {
       description: 'Default: 1',
     },
   },
-  properties: ['data', 'nrOfColumns'],
+  properties: ['nrOfColumns'],
   initialContent: {
     nrOfColumns: '1',
   },


### PR DESCRIPTION
The UI already shows a dedicated "Data" section.