### PR TITLE
disableResponsiveAdaption now part of ColumnsEditorTab

### DIFF
--- a/src/Widgets/ColumnContainerWidget/ColumnContainerWidgetEditingConfig.ts
+++ b/src/Widgets/ColumnContainerWidget/ColumnContainerWidgetEditingConfig.ts
@@ -7,11 +7,6 @@ import Thumbnail from './thumbnail.svg'
 provideEditingConfig(ColumnContainerWidget, {
   title: 'Columns',
   thumbnail: Thumbnail,
-  attributes: {
-    disableResponsiveAdaption: {
-      title: 'Disable responsive adaption?',
-    },
-  },
   propertiesGroups: [
     {
       title: 'Columns layout',
@@ -20,12 +15,6 @@ provideEditingConfig(ColumnContainerWidget, {
       // Cast is a working around for issue #9925
       // TODO: remove work around
       component: ColumnsEditorTab as unknown as null,
-    },
-
-    {
-      title: 'Responsive Adaptions',
-      key: 'responsive-adaptions',
-      properties: ['disableResponsiveAdaption'],
     },
   ],
   initialContent: {

--- a/src/Widgets/ColumnContainerWidget/ColumnsEditorTab.scss
+++ b/src/Widgets/ColumnContainerWidget/ColumnsEditorTab.scss
@@ -405,3 +405,137 @@
     color: #fff;
   }
 }
+
+// --------------------------------------------------------- //
+// scrivito_switch
+// --------------------------------------------------------- //
+
+.scrivito_switch {
+  display: inline-table;
+  position: relative;
+  vertical-align: top;
+  border-radius: 4px;
+  box-shadow: 0 0 2px 0 rgba(0, 0, 0, 0.2) inset;
+  margin: 3px 4px 3px 0;
+  cursor: pointer;
+  background: #cfcfcf;
+  color: #666;
+  font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
+  font-size: 13px;
+  font-weight: normal;
+  border-collapse: collapse;
+  user-select: none;
+  transition: all 0.3s ease;
+}
+.scrivito_switch:hover {
+  background: #d3d3d3;
+  box-shadow: 0 0 2px 0 rgba(0, 0, 0, 0.25) inset;
+}
+.scrivito_switch .cell {
+  display: table-cell;
+  position: relative;
+  vertical-align: middle;
+  text-align: center;
+  min-width: 50px;
+  width: 50%;
+  margin: 2px;
+  top: 0;
+  bottom: 0;
+  border-radius: 3px;
+  padding: 6px 15px;
+  line-height: 16px;
+  transition: color 0.2s ease;
+}
+.scrivito_switch .pill-wrapper {
+  display: table-row;
+}
+.scrivito_switch .pill {
+  position: absolute;
+  background: #fafafa;
+  left: 0;
+  margin-left: 2px;
+  transition: left 0.3s ease;
+}
+.scrivito_switch.active .pill {
+  background: #426698;
+  left: 50%;
+  margin-left: -2px;
+}
+.scrivito_switch.active:hover .pill {
+  background: #426698;
+  color: #fff;
+}
+
+.scrivito_switch .left {
+  color: #555;
+}
+.scrivito_switch.active .left {
+  color: #666;
+}
+.scrivito_switch .right {
+  color: #666;
+}
+.scrivito_switch.active .right {
+  color: #fff;
+}
+.scrivito_switch .cell .scrivito_icon {
+  color: #666;
+  font-size: 12px;
+  padding: 0px 8px 2px 2px;
+  margin-left: -5px;
+}
+.scrivito_switch.active .cell.left .scrivito_icon {
+  color: #666;
+}
+.scrivito_switch.active .cell .scrivito_icon {
+  color: #fff;
+}
+
+//-- two_valued --//
+
+.scrivito_switch.two_valued .right {
+  color: #666;
+}
+.scrivito_switch.two_valued.active .pill,
+.scrivito_switch.two_valued.active:hover .pill {
+  background: #fff;
+}
+
+//-- scrivito_disabled --//
+
+.scrivito_disabled .scrivito_switch {
+  cursor: default !important;
+}
+.scrivito_disabled .scrivito_switch.active .pill,
+.scrivito_disabled .scrivito_switch.active:hover .pill {
+  background: #555;
+  color: #fff;
+}
+
+// -- scrivito_dark adaptons -- //
+
+.scrivito_dark {
+  .scrivito_switch {
+    background: #3a3a3a;
+    box-shadow: 0 0 2px 0 rgba(0, 0, 0, 0.4) inset;
+  }
+  .scrivito_switch .left,
+  .scrivito_switch.active .right {
+    color: #eee;
+  }
+  .scrivito_switch .right,
+  .scrivito_switch.active .left {
+    color: #999;
+  }
+
+  .scrivito_switch .pill {
+    background: #5f5f5f;
+  }
+  .scrivito_switch.active .pill {
+    background: #426698;
+  }
+
+  .state_before .scrivito_switch.active .pill {
+    background: #777;
+  }
+}

--- a/src/Widgets/ColumnContainerWidget/ColumnsEditorTab.tsx
+++ b/src/Widgets/ColumnContainerWidget/ColumnsEditorTab.tsx
@@ -165,6 +165,36 @@ const ColumnsEditor = connect(
             readOnly={readOnly}
           />
         </div>
+
+
+        <div className="scrivito_detail_label">
+          <span style={{fontSize: "11px"}}>Disable responsive adaption?</span>
+        </div>
+
+        <div className="item_content">
+          <div className="boolean_attribute_component">
+            <div className="scrivito_switch">
+              <div className="pill-wrapper">
+                <div className="cell pill"></div>
+              </div>
+              <div className="cell left">Nein</div>
+              <div className="cell right">Ja</div>
+            </div>
+          </div>
+        </div>
+        <div className="item_content">
+          <div className="boolean_attribute_component">
+            <div className="scrivito_switch active">
+              <div className="pill-wrapper">
+                <div className="cell pill"></div>
+              </div>
+              <div className="cell left">Nein</div>
+              <div className="cell right">Ja</div>
+            </div>
+          </div>
+        </div>
+
+
       </div>
     )
 

--- a/src/Widgets/ColumnContainerWidget/ColumnsEditorTab.tsx
+++ b/src/Widgets/ColumnContainerWidget/ColumnsEditorTab.tsx
@@ -166,9 +166,8 @@ const ColumnsEditor = connect(
           />
         </div>
 
-
         <div className="scrivito_detail_label">
-          <span style={{fontSize: "11px"}}>Disable responsive adaption?</span>
+          <span style={{ fontSize: '11px' }}>Disable responsive adaption?</span>
         </div>
 
         <div className="item_content">
@@ -193,8 +192,6 @@ const ColumnsEditor = connect(
             </div>
           </div>
         </div>
-
-
       </div>
     )
 

--- a/src/Widgets/ColumnContainerWidget/ColumnsEditorTab.tsx
+++ b/src/Widgets/ColumnContainerWidget/ColumnsEditorTab.tsx
@@ -176,8 +176,8 @@ const ColumnsEditor = connect(
               <div className="pill-wrapper">
                 <div className="cell pill"></div>
               </div>
-              <div className="cell left">Nein</div>
-              <div className="cell right">Ja</div>
+              <div className="cell left">No</div>
+              <div className="cell right">Yes</div>
             </div>
           </div>
         </div>
@@ -187,8 +187,8 @@ const ColumnsEditor = connect(
               <div className="pill-wrapper">
                 <div className="cell pill"></div>
               </div>
-              <div className="cell left">Nein</div>
-              <div className="cell right">Ja</div>
+              <div className="cell left">No</div>
+              <div className="cell right">Yes</div>
             </div>
           </div>
         </div>

--- a/src/Widgets/ColumnContainerWidget/ColumnsEditorTab.tsx
+++ b/src/Widgets/ColumnContainerWidget/ColumnsEditorTab.tsx
@@ -172,23 +172,30 @@ const ColumnsEditor = connect(
 
         <div className="item_content">
           <div className="boolean_attribute_component">
-            <div className="scrivito_switch">
+            <div
+              className={`scrivito_switch${
+                widget.get('disableResponsiveAdaption') ? ' active' : ''
+              }`}
+            >
               <div className="pill-wrapper">
                 <div className="cell pill"></div>
               </div>
-              <div className="cell left">No</div>
-              <div className="cell right">Yes</div>
-            </div>
-          </div>
-        </div>
-        <div className="item_content">
-          <div className="boolean_attribute_component">
-            <div className="scrivito_switch active">
-              <div className="pill-wrapper">
-                <div className="cell pill"></div>
+              <div
+                className="cell left"
+                onClick={() =>
+                  widget.update({ disableResponsiveAdaption: false })
+                }
+              >
+                No
               </div>
-              <div className="cell left">No</div>
-              <div className="cell right">Yes</div>
+              <div
+                className="cell right"
+                onClick={() =>
+                  widget.update({ disableResponsiveAdaption: true })
+                }
+              >
+                Yes
+              </div>
             </div>
           </div>
         </div>


### PR DESCRIPTION
Before:
<img width="462" alt="disableResponsiveAdaption before" src="https://github.com/Scrivito/scrivito-portal-app/assets/86275/989fd2e3-84dd-46c0-bc1c-b9cd79c4adef">

After:
<img width="460" alt="disableResponsiveAdaption after" src="https://github.com/Scrivito/scrivito-portal-app/assets/86275/e9fe3d2c-90bc-4e0d-8f1c-f62b641511c6">

Thanks to @agessler for the design!
