### PR TITLE
Weekly Dependabot ignores major updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,5 +5,8 @@ updates:
     groups:
       update:
         patterns: ['*']
+    ignore:
+      - dependency-name: '*'
+        update-types: ['version-update:semver-major']
     schedule:
       interval: 'weekly'


### PR DESCRIPTION
FYI If I understand the docs correctly we could also configure Dependabot to inform us about major updates independently from the weekly check by configuring [`groups.update-types`](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups) instead of ignoring them globally.