### PR TITLE
Dependabot: Create one PR per major update

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,10 +3,18 @@ updates:
   - package-ecosystem: 'npm'
     directory: '/'
     groups:
-      update:
+      update-patch-minor:
         patterns: ['*']
+        update-types:
+          - 'minor'
+          - 'patch'
+    schedule:
+      interval: 'weekly'
+  - package-ecosystem: 'npm'
+    directory: '/'
     ignore:
       - dependency-name: '*'
-        update-types: ['version-update:semver-major']
+        update-types:
+          ['version-update:semver-minor', 'version-update:semver-patch']
     schedule:
       interval: 'weekly'


### PR DESCRIPTION
Inspired by https://github.blog/changelog/2021-05-21-dependabot-version-updates-can-now-ignore-major-minor-patch-releases/