### PR TITLE
Fix dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,11 +10,3 @@ updates:
           - 'patch'
     schedule:
       interval: 'weekly'
-  - package-ecosystem: 'npm'
-    directory: '/'
-    ignore:
-      - dependency-name: '*'
-        update-types:
-          ['version-update:semver-minor', 'version-update:semver-patch']
-    schedule:
-      interval: 'weekly'


### PR DESCRIPTION
As we already group patch and minor updates in `update-patch-minor` the remaining updates can only be major ones, so no need to ignore anything.