### PR TITLE
Downgrade sass to avoid deprecation warnings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,7 @@
         "eslint-plugin-react": "^7.33.2",
         "eslint-plugin-react-hooks": "^4.6.0",
         "prettier": "^3.1.1",
-        "sass": "^1.69.7",
+        "sass": "1.64.x",
         "typescript": "^5.3.3",
         "vite": "^5.0.10"
       }
@@ -4063,9 +4063,9 @@
       }
     },
     "node_modules/sass": {
-      "version": "1.69.7",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.69.7.tgz",
-      "integrity": "sha512-rzj2soDeZ8wtE2egyLXgOOHQvaC2iosZrkF6v3EUG+tBwEvhqUCzm0VP3k9gHF9LXbSrRhT5SksoI56Iw8NPnQ==",
+      "version": "1.64.2",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.64.2.tgz",
+      "integrity": "sha512-TnDlfc+CRnUAgLO9D8cQLFu/GIjJIzJCGkE7o4ekIGQOH7T3GetiRR/PsTWJUHhkzcSPrARkPI+gNWn5alCzDg==",
       "dev": true,
       "dependencies": {
         "chokidar": ">=3.0.0 <4.0.0",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "eslint-plugin-react": "^7.33.2",
     "eslint-plugin-react-hooks": "^4.6.0",
     "prettier": "^3.1.1",
-    "sass": "^1.69.7",
+    "sass": "1.64.x",
     "typescript": "^5.3.3",
     "vite": "^5.0.10"
   }


### PR DESCRIPTION
with bootstrap 5.2

Avoids https://app.circleci.com/pipelines/github/Scrivito/scrivito-portal-app/509/workflows/151a0c89-1d84-4d24-af6d-8a083e201a54/jobs/1303?invite=true#step-103-106_89