### PR TITLE
DataFormContainer: Reset a form after submit (create only)

### DIFF
--- a/src/Widgets/DataFormContainerWidget/DataFormContainerWidgetComponent.tsx
+++ b/src/Widgets/DataFormContainerWidget/DataFormContainerWidgetComponent.tsx
@@ -61,6 +61,7 @@ provideComponent(DataFormContainerWidget, ({ widget }) => {
       } else {
         const createdItem = await dataScope.create(attributes)
         toastAndRedirect(createdItem)
+        formRef.current.reset()
       }
     } catch (error) {
       if (!(error instanceof Error)) return


### PR DESCRIPTION
This allows to reuse a form to send multiple message, when staying on the same page. E.g. when inside of a footer of #227.