### PR TITLE
DataListWidget: Allow to show footer

### DIFF
--- a/src/Widgets/DataListWidget/DataListWidgetClass.ts
+++ b/src/Widgets/DataListWidget/DataListWidgetClass.ts
@@ -4,7 +4,9 @@ export const DataListWidget = provideWidgetClass('DataListWidget', {
   attributes: {
     content: 'widgetlist',
     data: 'datalocator',
+    footer: 'widgetlist',
     nothingFound: 'widgetlist',
     nrOfColumns: ['enum', { values: ['1', '2', '3', '4', '5', '6'] }],
+    showFooter: 'boolean',
   },
 })

--- a/src/Widgets/DataListWidget/DataListWidgetComponent.tsx
+++ b/src/Widgets/DataListWidget/DataListWidgetComponent.tsx
@@ -37,6 +37,24 @@ provideComponent(DataListWidget, ({ widget }) => {
       {(dataScope.isEmpty() || isInPlaceEditingActive()) && (
         <ContentTag content={widget} attribute="nothingFound" />
       )}
+      {widget.get('showFooter') ? (
+        <>
+          {isInPlaceEditingActive() && (
+            <div className="alert alert-warning d-flex m-auto">
+              <i
+                className="bi bi-exclamation-circle bi-2x"
+                aria-hidden="true"
+              ></i>
+              <div className="my-auto mx-2">
+                <b>Editor note:</b> The following is the data list footer and is
+                always visible - regardless of the number of items in
+                &quot;data&quot;.
+              </div>
+            </div>
+          )}
+          <ContentTag content={widget} attribute="footer" />
+        </>
+      ) : null}
     </>
   )
 })

--- a/src/Widgets/DataListWidget/DataListWidgetEditingConfig.ts
+++ b/src/Widgets/DataListWidget/DataListWidgetEditingConfig.ts
@@ -10,8 +10,9 @@ provideEditingConfig(DataListWidget, {
       title: 'Number of columns',
       description: 'Default: 1',
     },
+    showFooter: { title: 'Show footer?' },
   },
-  properties: ['nrOfColumns'],
+  properties: ['showFooter', 'nrOfColumns'],
   initialContent: {
     nrOfColumns: '1',
   },


### PR DESCRIPTION
Adds an option to show a footer for a data list widget. This allows to e.g. add a data form to push items to the data list widget list.