### PR TITLE
Run dependabot only once a month

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,4 +9,4 @@ updates:
           - 'minor'
           - 'patch'
     schedule:
-      interval: 'weekly'
+      interval: 'monthly'


### PR DESCRIPTION
Once a week is too much noise for me.

I did not find a good way to delay "major" updates for e.g. a week or a month. Thoughts?