### PR TITLE
DataAttachmentsWidget bugfix: isFullBinaryArray no longer loops itself.

### DIFF
--- a/src/Widgets/DataAttachmentsWidget/DataAttachmentsWidgetComponent.tsx
+++ b/src/Widgets/DataAttachmentsWidget/DataAttachmentsWidgetComponent.tsx
@@ -93,5 +93,5 @@ function BoxPreviewContent({
 }
 
 function isFullBinaryArray(input: unknown): input is FullDataBinary[] {
-  return Array.isArray(input) && input.every(isFullBinaryArray)
+  return Array.isArray(input) && input.every(isFullDataBinary)
 }


### PR DESCRIPTION
Introduced in https://github.com/Scrivito/scrivito-portal-app/pull/304.