### PR TITLE
DataListWidget: Drop datalocator

### DIFF
--- a/src/Widgets/DataListWidget/DataListWidgetClass.ts
+++ b/src/Widgets/DataListWidget/DataListWidgetClass.ts
@@ -4,7 +4,6 @@ export const DataListWidget = provideWidgetClass('DataListWidget', {
   attributes: {
     content: 'widgetlist',
     data: 'datalocator',
-    footer: 'widgetlist',
     nrOfColumns: ['enum', { values: ['1', '2', '3', '4', '5', '6'] }],
   },
 })

--- a/src/Widgets/DataListWidget/DataListWidgetClass.ts
+++ b/src/Widgets/DataListWidget/DataListWidgetClass.ts
@@ -3,7 +3,6 @@ import { provideWidgetClass } from 'scrivito'
 export const DataListWidget = provideWidgetClass('DataListWidget', {
   attributes: {
     content: 'widgetlist',
-    data: 'datalocator',
     nrOfColumns: ['enum', { values: ['1', '2', '3', '4', '5', '6'] }],
   },
 })

--- a/src/Widgets/DataListWidget/DataListWidgetComponent.tsx
+++ b/src/Widgets/DataListWidget/DataListWidgetComponent.tsx
@@ -1,9 +1,23 @@
-import { ContentTag, provideComponent, useDataLocator } from 'scrivito'
+import {
+  ContentTag,
+  DataScope,
+  provideComponent,
+  // @ts-expect-error TODO: remove once officially released
+  useDataScope,
+} from 'scrivito'
 import { DataListWidget } from './DataListWidgetClass'
+import { EditorNote } from '../../Components/EditorNote'
 
 provideComponent(DataListWidget, ({ widget }) => {
-  const data = widget.get('data')
-  const dataScope = useDataLocator(data)
+  const dataScope: DataScope | undefined = useDataScope()
+
+  if (!dataScope) {
+    return <EditorNote>No data found. Please select a data source.</EditorNote>
+  }
+
+  if (dataScope.isEmpty()) {
+    return <EditorNote>Data list is empty.</EditorNote>
+  }
 
   const nrOfColumns = widget.get('nrOfColumns') || '1'
 

--- a/src/Widgets/DataListWidget/DataListWidgetComponent.tsx
+++ b/src/Widgets/DataListWidget/DataListWidgetComponent.tsx
@@ -16,7 +16,7 @@ provideComponent(DataListWidget, ({ widget }) => {
   }
 
   if (dataScope.isEmpty()) {
-    return <EditorNote>Data list is empty.</EditorNote>
+    return <EditorNote>The data list is empty.</EditorNote>
   }
 
   const nrOfColumns = widget.get('nrOfColumns') || '1'

--- a/src/Widgets/DataListWidget/DataListWidgetComponent.tsx
+++ b/src/Widgets/DataListWidget/DataListWidgetComponent.tsx
@@ -8,18 +8,16 @@ provideComponent(DataListWidget, ({ widget }) => {
   const nrOfColumns = widget.get('nrOfColumns') || '1'
 
   return (
-    <>
-      <div className={`row row-cols-1 row-cols-md-${nrOfColumns}`}>
-        {dataScope.take().map((dataItem) => (
-          <ContentTag
-            content={widget}
-            attribute="content"
-            className="col"
-            dataContext={dataItem}
-            key={dataItem.id()}
-          />
-        ))}
-      </div>
-    </>
+    <div className={`row row-cols-1 row-cols-md-${nrOfColumns}`}>
+      {dataScope.take().map((dataItem) => (
+        <ContentTag
+          content={widget}
+          attribute="content"
+          className="col"
+          dataContext={dataItem}
+          key={dataItem.id()}
+        />
+      ))}
+    </div>
   )
 })


### PR DESCRIPTION
As outlined before the goal is, to only set a datalocator either on the page or in a "DataGroupWidget". All other widgets should _not_ (for now) define a datalocator.

Live preview: https://edit.scrivito.com/d0a154d76edf2a7bd991fc658e700a1d~https://drop-datalocator.scrivito-portal-app.pages.dev/my-tynacoon?_scrivito_workspace_id=lad559fcb11b188b&_scrivito_display_mode=view