### PR TITLE
DataLabelWidget: More date options

### DIFF
--- a/src/Widgets/DataLabelWidget/DataLabelWidgetClass.ts
+++ b/src/Widgets/DataLabelWidget/DataLabelWidgetClass.ts
@@ -6,6 +6,7 @@ export const DataLabelWidget = provideWidgetClass('DataLabelWidget', {
     attributeName: 'string',
     details: 'string',
     showAs: ['enum', { values: ['text', 'currency', 'datetime', 'link'] }],
+    datetimeFormat: ['enum', { values: ['date', 'datetime', 'relative'] }],
     valueSize: [
       'enum',
       {

--- a/src/Widgets/DataLabelWidget/DataLabelWidgetComponent.tsx
+++ b/src/Widgets/DataLabelWidget/DataLabelWidgetComponent.tsx
@@ -7,6 +7,12 @@ import {
 } from 'scrivito'
 import { DataLabelWidget } from './DataLabelWidgetClass'
 import { RelativeDate } from './RelativeDate'
+import {
+  formatDateMonthAndYear,
+  formatDateTime,
+  formatFullDateTime,
+  formatFullDayAndMonth,
+} from '../../utils/formatDate'
 
 const CURRENCY = 'EUR' // ISO 4217 Code
 
@@ -30,6 +36,7 @@ provideComponent(DataLabelWidget, ({ widget }) => {
       <div className={valueCssClassNames.join(' ')}>
         <AttributeValue
           attributeValue={dataItem?.get(widget.get('attributeName'))}
+          datetimeFormat={widget.get('datetimeFormat')}
           showAs={widget.get('showAs')}
         />
       </div>
@@ -46,13 +53,17 @@ provideComponent(DataLabelWidget, ({ widget }) => {
 
 const AttributeValue = connect(function AttributeValue({
   attributeValue,
+  datetimeFormat,
   showAs,
 }: {
   attributeValue: unknown
+  datetimeFormat: string | null
   showAs: string | null
 }) {
   if (showAs === 'currency') return <Currency value={attributeValue} />
-  if (showAs === 'datetime') return <Datetime value={attributeValue} />
+  if (showAs === 'datetime') {
+    return <Datetime value={attributeValue} datetimeFormat={datetimeFormat} />
+  }
   if (showAs === 'link') return <Link value={attributeValue} />
 
   return <Text value={attributeValue} />
@@ -76,12 +87,30 @@ function Currency({ value }: { value: unknown }) {
   return formatter.format(number)
 }
 
-function Datetime({ value }: { value: unknown }) {
+function Datetime({
+  value,
+  datetimeFormat,
+}: {
+  value: unknown
+  datetimeFormat: string | null
+}) {
   if (value === null) return 'N/A'
   if (typeof value !== 'string') return 'N/A'
 
   const date = new Date(value)
   if (Number.isNaN(date.getTime())) return 'N/A'
+
+  if (datetimeFormat === 'date') {
+    return (
+      <span title={formatFullDayAndMonth(date)}>
+        {formatDateMonthAndYear(date)}
+      </span>
+    )
+  }
+
+  if (datetimeFormat === 'datetime') {
+    return <span title={formatFullDateTime(date)}>{formatDateTime(date)}</span>
+  }
 
   return <RelativeDate date={date} />
 }

--- a/src/Widgets/DataLabelWidget/DataLabelWidgetEditingConfig.ts
+++ b/src/Widgets/DataLabelWidget/DataLabelWidgetEditingConfig.ts
@@ -1,6 +1,7 @@
 import { provideEditingConfig } from 'scrivito'
 import { DataLabelWidget } from './DataLabelWidgetClass'
 import Thumbnail from './thumbnail.svg'
+import { isString } from 'lodash-es'
 
 provideEditingConfig(DataLabelWidget, {
   title: 'Data Label',
@@ -17,11 +18,27 @@ provideEditingConfig(DataLabelWidget, {
         { value: 'link', title: 'Link' },
       ],
     },
+    datetimeFormat: {
+      title: 'Date format',
+      description: 'Default: Relative',
+      values: [
+        { value: 'relative', title: 'Relative' },
+        { value: 'datetime', title: 'Date and time' },
+        { value: 'date', title: 'Only date' },
+      ],
+    },
     marginBottom: {
       title: 'Add margin bottom?',
     },
   },
-  properties: ['attributeName', 'showAs', 'valueSize', 'marginBottom'],
+  properties: (widget) =>
+    [
+      'attributeName',
+      'showAs',
+      widget.get('showAs') === 'datetime' ? 'datetimeFormat' : null,
+      'valueSize',
+      'marginBottom',
+    ].filter(isString),
   initialContent: {
     label: 'Label',
     showAs: 'text',

--- a/src/Widgets/DataLabelWidget/RelativeDate.tsx
+++ b/src/Widgets/DataLabelWidget/RelativeDate.tsx
@@ -1,8 +1,12 @@
 import { formatDistance } from 'date-fns'
 import { useEffect, useState } from 'react'
+import {
+  formatDateMonthAndYear,
+  formatDayAndMonth,
+  formatFullDateTime,
+} from '../../utils/formatDate'
 
 const MONTH_IN_MS = 30 * 24 * 60 * 60 * 1000
-const dateTimeFormatLocale = 'en-GB'
 
 export function RelativeDate({ date }: { date: Date }) {
   const [currentDate, setCurrentDate] = useState(new Date())
@@ -32,26 +36,4 @@ function DisplayDate({ currentDate, date }: { currentDate: Date; date: Date }) {
   }
 
   return formatDateMonthAndYear(date)
-}
-
-function formatFullDateTime(date: Date): string {
-  return new Intl.DateTimeFormat(dateTimeFormatLocale, {
-    dateStyle: 'full',
-    timeStyle: 'long',
-  }).format(date)
-}
-
-function formatDayAndMonth(date: Date) {
-  return new Intl.DateTimeFormat(dateTimeFormatLocale, {
-    month: 'short',
-    day: 'numeric',
-  }).format(date)
-}
-
-function formatDateMonthAndYear(date: Date) {
-  return new Intl.DateTimeFormat(dateTimeFormatLocale, {
-    year: 'numeric',
-    month: 'short',
-    day: 'numeric',
-  }).format(date)
 }

--- a/src/utils/formatDate.ts
+++ b/src/utils/formatDate.ts
@@ -1,5 +1,15 @@
 const dateTimeFormatLocale = 'en-GB'
 
+export function formatDateTime(date: Date) {
+  return new Intl.DateTimeFormat(dateTimeFormatLocale, {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: 'numeric',
+  }).format(date)
+}
+
 export function formatFullDateTime(date: Date): string {
   return new Intl.DateTimeFormat(dateTimeFormatLocale, {
     dateStyle: 'full',
@@ -11,6 +21,12 @@ export function formatDayAndMonth(date: Date) {
   return new Intl.DateTimeFormat(dateTimeFormatLocale, {
     month: 'short',
     day: 'numeric',
+  }).format(date)
+}
+
+export function formatFullDayAndMonth(date: Date) {
+  return new Intl.DateTimeFormat(dateTimeFormatLocale, {
+    dateStyle: 'full',
   }).format(date)
 }
 

--- a/src/utils/formatDate.ts
+++ b/src/utils/formatDate.ts
@@ -1,0 +1,23 @@
+const dateTimeFormatLocale = 'en-GB'
+
+export function formatFullDateTime(date: Date): string {
+  return new Intl.DateTimeFormat(dateTimeFormatLocale, {
+    dateStyle: 'full',
+    timeStyle: 'long',
+  }).format(date)
+}
+
+export function formatDayAndMonth(date: Date) {
+  return new Intl.DateTimeFormat(dateTimeFormatLocale, {
+    month: 'short',
+    day: 'numeric',
+  }).format(date)
+}
+
+export function formatDateMonthAndYear(date: Date) {
+  return new Intl.DateTimeFormat(dateTimeFormatLocale, {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+  }).format(date)
+}


### PR DESCRIPTION
Allows to format a date value as "Date and time" and "Only date". "Relative" was previously already available.

Needs content: https://edit.scrivito.com/d0a154d76edf2a7bd991fc658e700a1d~https://datalabelwidget-date.scrivito-portal-app.pages.dev/my-tynacoon?_scrivito_workspace_id=mc2dbbd39b44e23a&_scrivito_display_mode=view