### PR TITLE
DataFormContainer: Work properly inside of links

### DIFF
--- a/src/Widgets/DataFormContainerWidget/DataFormContainerWidgetComponent.tsx
+++ b/src/Widgets/DataFormContainerWidget/DataFormContainerWidgetComponent.tsx
@@ -44,6 +44,9 @@ provideComponent(DataFormContainerWidget, ({ widget }) => {
         onSubmit={onSubmit}
         onReset={onReset}
         className={isSubmitting ? 'form-loading' : ''}
+        onClick={(e) => {
+          e.stopPropagation()
+        }}
       >
         <InPlaceEditingOff>
           <ContentTag content={widget} attribute="hiddenFields" />

--- a/src/Widgets/DataFormContainerWidget/DataFormContainerWidgetComponent.tsx
+++ b/src/Widgets/DataFormContainerWidget/DataFormContainerWidgetComponent.tsx
@@ -44,9 +44,6 @@ provideComponent(DataFormContainerWidget, ({ widget }) => {
         onSubmit={onSubmit}
         onReset={onReset}
         className={isSubmitting ? 'form-loading' : ''}
-        onClick={(e) => {
-          e.stopPropagation()
-        }}
       >
         <InPlaceEditingOff>
           <ContentTag content={widget} attribute="hiddenFields" />

--- a/src/Widgets/DataFormSubmitButtonWidget/DataFormSubmitButtonWidgetComponent.tsx
+++ b/src/Widgets/DataFormSubmitButtonWidget/DataFormSubmitButtonWidgetComponent.tsx
@@ -7,6 +7,7 @@ import {
 import { alignmentClassNameWithBlock } from '../../utils/alignmentClassName'
 import { DataFormSubmitButtonWidget } from './DataFormSubmitButtonWidgetClass'
 import { buttonSizeClassName } from '../../utils/buttonSizeClassName'
+import { MouseEvent } from 'react'
 
 provideComponent(DataFormSubmitButtonWidget, ({ widget }) => {
   const baseButtonStyles = ['btn']
@@ -22,9 +23,7 @@ provideComponent(DataFormSubmitButtonWidget, ({ widget }) => {
           attribute="submitTitle"
           type="submit"
           className={`${baseButtonStyles.join(' ')} btn-primary`}
-          onClick={(e: unknown) => {
-            if (supportsStopPropagation(e)) e.stopPropagation()
-          }}
+          onClick={(e: MouseEvent<'button'>) => e.stopPropagation()}
         ></ContentTag>{' '}
         {widget.get('hasReset') && (
           <ContentTag
@@ -33,9 +32,7 @@ provideComponent(DataFormSubmitButtonWidget, ({ widget }) => {
             attribute="resetTitle"
             type="reset"
             className={`${baseButtonStyles.join(' ')} btn-danger`}
-            onClick={(e: unknown) => {
-              if (supportsStopPropagation(e)) e.stopPropagation()
-            }}
+            onClick={(e: MouseEvent<'button'>) => e.stopPropagation()}
           >
             {widget.get('resetTitle')}
           </ContentTag>
@@ -44,9 +41,3 @@ provideComponent(DataFormSubmitButtonWidget, ({ widget }) => {
     </WidgetTag>
   )
 })
-
-function supportsStopPropagation(e: unknown): e is { stopPropagation(): void } {
-  return (
-    typeof (e as { stopPropagation(): void })?.stopPropagation === 'function'
-  )
-}

--- a/src/Widgets/DataFormSubmitButtonWidget/DataFormSubmitButtonWidgetComponent.tsx
+++ b/src/Widgets/DataFormSubmitButtonWidget/DataFormSubmitButtonWidgetComponent.tsx
@@ -22,6 +22,9 @@ provideComponent(DataFormSubmitButtonWidget, ({ widget }) => {
           attribute="submitTitle"
           type="submit"
           className={`${baseButtonStyles.join(' ')} btn-primary`}
+          onClick={(e: unknown) => {
+            if (supportsStopPropagation(e)) e.stopPropagation()
+          }}
         ></ContentTag>{' '}
         {widget.get('hasReset') && (
           <ContentTag
@@ -30,6 +33,9 @@ provideComponent(DataFormSubmitButtonWidget, ({ widget }) => {
             attribute="resetTitle"
             type="reset"
             className={`${baseButtonStyles.join(' ')} btn-danger`}
+            onClick={(e: unknown) => {
+              if (supportsStopPropagation(e)) e.stopPropagation()
+            }}
           >
             {widget.get('resetTitle')}
           </ContentTag>
@@ -38,3 +44,9 @@ provideComponent(DataFormSubmitButtonWidget, ({ widget }) => {
     </WidgetTag>
   )
 })
+
+function supportsStopPropagation(e: unknown): e is { stopPropagation(): void } {
+  return (
+    typeof (e as { stopPropagation(): void })?.stopPropagation === 'function'
+  )
+}


### PR DESCRIPTION
E.g. clicking on the submit button propagates to an upper link, if the propagation is not stopped.

Follow-up of https://github.com/Scrivito/scrivito-portal-app/pull/332#discussion_r1527621580.

Example Content (**not to be published!**): https://edit.scrivito.com/d0a154d76edf2a7bd991fc658e700a1d~https://dataformcontainer-bugfix.scrivito-portal-app.pages.dev/events-fb302b23c46fea41?_scrivito_workspace_id=v667419e005c44b6&_scrivito_display_mode=view