### PR TITLE
Remove Headline from DataPersonCardWidget

### DIFF
--- a/src/Widgets/DataPersonCardWidget/DataPersonCardWidgetClass.ts
+++ b/src/Widgets/DataPersonCardWidget/DataPersonCardWidgetClass.ts
@@ -3,6 +3,5 @@ import { provideWidgetClass } from 'scrivito'
 export const DataPersonCardWidget = provideWidgetClass('DataPersonCardWidget', {
   attributes: {
     data: 'datalocator',
-    headline: 'string',
   },
 })

--- a/src/Widgets/DataPersonCardWidget/DataPersonCardWidgetComponent.tsx
+++ b/src/Widgets/DataPersonCardWidget/DataPersonCardWidgetComponent.tsx
@@ -1,12 +1,10 @@
 import {
   provideComponent,
-  WidgetTag,
   // @ts-expect-error TODO: remove once officially released
   useDataScope,
   DataScope,
   connect,
   DataItem,
-  ContentTag,
 } from 'scrivito'
 
 import { DataBinaryImage } from '../../Components/DataBinaryImage'
@@ -16,7 +14,7 @@ import { DataPersonCardWidget } from './DataPersonCardWidgetClass'
 import { EditorNote } from '../../Components/EditorNote'
 import personCircle from '../../assets/images/person-circle.svg'
 
-provideComponent(DataPersonCardWidget, ({ widget }) => {
+provideComponent(DataPersonCardWidget, () => {
   const dataScope: DataScope | undefined = useDataScope()
 
   if (!dataScope) {
@@ -26,17 +24,11 @@ provideComponent(DataPersonCardWidget, ({ widget }) => {
   if (dataScope.isEmpty()) return <EditorNote>Data is empty.</EditorNote>
 
   return (
-    <WidgetTag>
-      <ContentTag
-        content={widget}
-        attribute="headline"
-        tag="h6"
-        className="h6 text-uppercase"
-      />
+    <>
       {dataScope.take().map((dataItem) => (
         <PersonCard dataItem={dataItem} key={dataItem.id()} />
       ))}
-    </WidgetTag>
+    </>
   )
 })
 

--- a/src/Widgets/DataPersonCardWidget/DataPersonCardWidgetEditingConfig.ts
+++ b/src/Widgets/DataPersonCardWidget/DataPersonCardWidgetEditingConfig.ts
@@ -5,8 +5,4 @@ import Thumbnail from './thumbnail.svg'
 provideEditingConfig(DataPersonCardWidget, {
   title: 'Data Person Card',
   thumbnail: Thumbnail,
-  properties: ['headline'],
-  initialContent: {
-    headline: 'Your sales representative',
-  },
 })


### PR DESCRIPTION
It's better to leave this to a regular HeadlineWidget with all its options.

Needs content - please also check the event details page: https://edit.scrivito.com/d0a154d76edf2a7bd991fc658e700a1d~https://simpler-datapersoncardwidget.scrivito-portal-app.pages.dev/my-tynacoon?_scrivito_workspace_id=p81a8ca32bdb5135&_scrivito_display_mode=view