### PR TITLE
new dark UI colors and adaptions for column editor

### DIFF
--- a/src/Widgets/ColumnContainerWidget/ColumnsEditorTab.scss
+++ b/src/Widgets/ColumnContainerWidget/ColumnsEditorTab.scss
@@ -348,7 +348,7 @@
 .scrivito_dark {
   .gle-preview {
     border: 2px solid #777;
-    background: #555;
+    background: var(--jr-grey-light-hover);
   }
   .gle-preview.active {
     border: 2px solid #426698;
@@ -370,7 +370,7 @@
   }
   .gle {
     border: 2px solid #777;
-    background: #444;
+    background: var(--jr-grey-light);
   }
   .gle .grid-ruler {
     opacity: 0.4;

--- a/src/assets/stylesheets/scrivitoExtensions.scss
+++ b/src/assets/stylesheets/scrivitoExtensions.scss
@@ -2,6 +2,14 @@
 // general styles adaptions
 // --------------------------------------------------------------- //
 @import 'scrivito-neoletter-form-widgets/editing.css';
+:root {
+  --jr-grey-dark: #111418;
+  --jr-grey-middle: #1d2229;
+  --jr-grey-light: #272d37;
+  --jr-grey-light-hover: #3a4353;
+
+  --jr-blue-light: #426698;
+}
 
 html,
 body {
@@ -10,7 +18,7 @@ body {
 }
 
 .scrivito_dark {
-  background: #3f3f3f;
+  background: var(--jr-grey-middle);
 
   [data-scrivito-editors-placeholder]:empty:not(:focus):before {
     color: #aaa !important;


### PR DESCRIPTION
**mixed untouched (no dark adaptions)**
<img width="1229" alt="mixed-untouched" src="https://github.com/Scrivito/scrivito-portal-app/assets/710311/fb3e70d7-6fe5-4fab-8c54-56f2f5ba4cbe">

**current mixed (old dark adaptions)**
<img width="1216" alt="current-mixed" src="https://github.com/Scrivito/scrivito-portal-app/assets/710311/d4ef9c3f-6329-4c9f-8fc1-b99c9d9a9519">

**new adaptions**
<img width="1057" alt="new-adaptions" src="https://github.com/Scrivito/scrivito-portal-app/assets/710311/2d718152-04ce-49de-beff-fd878acfc936">


Should be merged when Scrivito Dark Mode is live...
