### PR TITLE
Multi-language basics

### DIFF
--- a/src/config/scrivito.ts
+++ b/src/config/scrivito.ts
@@ -1,5 +1,5 @@
 import { configure } from 'scrivito'
-import { getTenantFromEnv } from './scrivitoSites'
+import { getTenantFromEnv, baseUrlForSite, siteForUrl } from './scrivitoSites'
 
 export function configureScrivito() {
   const tenant = getTenantFromEnv()
@@ -8,9 +8,11 @@ export function configureScrivito() {
   const config: Parameters<typeof configure>[0] = {
     adoptUi: true,
     autoConvertAttributes: true,
+    baseUrlForSite,
     optimizedWidgetLoading: true,
     strictSearchOperators: true,
     contentTagsForEmptyAttributes: false,
+    siteForUrl,
     tenant,
     // @ts-expect-error // TODO: Remove later on
     unstable: {
@@ -24,7 +26,6 @@ export function configureScrivito() {
 
   if (!import.meta.env.SCRIVITO_TENANT) {
     // Multitenancy mode
-    config.routingBasePath = `/${tenant}`
     config.extensionsUrl = `/_scrivito_extensions.html?tenantId=${tenant}`
   }
 

--- a/src/config/scrivito.ts
+++ b/src/config/scrivito.ts
@@ -1,13 +1,17 @@
 import { configure } from 'scrivito'
+import { getTenantFromEnv } from './scrivitoSites'
 
 export function configureScrivito() {
+  const tenant = getTenantFromEnv()
+  if (!tenant) return
+
   const config: Parameters<typeof configure>[0] = {
     adoptUi: true,
     autoConvertAttributes: true,
     optimizedWidgetLoading: true,
     strictSearchOperators: true,
     contentTagsForEmptyAttributes: false,
-    tenant: import.meta.env.SCRIVITO_TENANT || '',
+    tenant,
     // @ts-expect-error // TODO: Remove later on
     unstable: {
       trustedUiOrigins: [
@@ -20,35 +24,6 @@ export function configureScrivito() {
 
   if (!import.meta.env.SCRIVITO_TENANT) {
     // Multitenancy mode
-    const tenantFromUrl =
-      window.location.pathname.match(/^\/([0-9a-f]{32})\b/)?.[1]
-    const tenantFromQuery = new URLSearchParams(window.location.search).get(
-      'tenantId',
-    )
-    const tenant = tenantFromUrl || tenantFromQuery
-
-    if (!tenant) {
-      if (
-        import.meta.env.VITE_MULTITENANCY_FALLBACK_SCRIVITO_TENANT &&
-        !tenantFromQuery
-      ) {
-        const fallbackScrivitoTenant = import.meta.env
-          .VITE_MULTITENANCY_FALLBACK_SCRIVITO_TENANT
-        if (
-          typeof fallbackScrivitoTenant === 'string' &&
-          fallbackScrivitoTenant.match(/^[0-9a-f]{32}$/)
-        ) {
-          window.location.replace(
-            `${window.location.origin}/${fallbackScrivitoTenant}`,
-          )
-          return
-        }
-      }
-
-      throw new Error('Could not determine tenant!')
-    }
-
-    config.tenant = tenant
     config.routingBasePath = `/${tenant}`
     config.extensionsUrl = `/_scrivito_extensions.html?tenantId=${tenant}`
   }

--- a/src/config/scrivito.ts
+++ b/src/config/scrivito.ts
@@ -1,5 +1,10 @@
 import { configure } from 'scrivito'
-import { getTenantFromEnv, baseUrlForSite, siteForUrl } from './scrivitoSites'
+import {
+  baseUrlForSite,
+  ensureSiteIsPresent,
+  getTenantFromEnv,
+  siteForUrl,
+} from './scrivitoSites'
 
 export function configureScrivito() {
   const tenant = getTenantFromEnv()
@@ -30,4 +35,5 @@ export function configureScrivito() {
   }
 
   configure(config)
+  ensureSiteIsPresent()
 }

--- a/src/config/scrivitoSites.ts
+++ b/src/config/scrivitoSites.ts
@@ -35,6 +35,14 @@ export function siteForUrl(
   if (baseUrl) return { baseUrl, siteId }
 }
 
+export async function ensureSiteIsPresent() {
+  if ((await load(currentSiteId)) === null) {
+    navigateTo(() =>
+      Obj.onAllSites().where('_path', 'equals', '/').order('_language').first(),
+    )
+  }
+}
+
 export function getTenantFromEnv(): string | undefined {
   if (import.meta.env.SCRIVITO_TENANT) return import.meta.env.SCRIVITO_TENANT
 

--- a/src/config/scrivitoSites.ts
+++ b/src/config/scrivitoSites.ts
@@ -1,0 +1,33 @@
+const location = typeof window !== 'undefined' ? window.location : undefined
+
+export function getTenantFromEnv(): string | undefined {
+  if (import.meta.env.SCRIVITO_TENANT) return import.meta.env.SCRIVITO_TENANT
+
+  if (!location) throw new Error('Could not determine tenant!')
+
+  // Multitenancy mode
+  const tenantFromUrl = location.pathname.match(/^\/([0-9a-f]{32})\b/)?.[1]
+  const tenantFromQuery = new URLSearchParams(location.search).get('tenantId')
+  const tenant = tenantFromUrl || tenantFromQuery
+
+  if (!tenant) {
+    if (
+      import.meta.env.VITE_MULTITENANCY_FALLBACK_SCRIVITO_TENANT &&
+      !tenantFromQuery
+    ) {
+      const fallbackScrivitoTenant = import.meta.env
+        .VITE_MULTITENANCY_FALLBACK_SCRIVITO_TENANT
+      if (
+        typeof fallbackScrivitoTenant === 'string' &&
+        fallbackScrivitoTenant.match(/^[0-9a-f]{32}$/)
+      ) {
+        location.replace(`${location.origin}/${fallbackScrivitoTenant}`)
+        return
+      }
+    }
+
+    throw new Error('Could not determine tenant!')
+  }
+
+  return tenant
+}

--- a/src/config/scrivitoSites.ts
+++ b/src/config/scrivitoSites.ts
@@ -1,5 +1,26 @@
 const location = typeof window !== 'undefined' ? window.location : undefined
 
+export function baseUrlForSite(_siteId: string): string | undefined {
+  const tenant = getTenantFromEnv()
+  if (!location || !tenant) return
+
+  const urlParts = [location.origin]
+
+  // Multitenancy mode
+  if (!import.meta.env.SCRIVITO_TENANT) urlParts.push(tenant)
+
+  return urlParts.join('/')
+}
+
+export function siteForUrl(
+  _url: string,
+): { baseUrl: string; siteId: string } | undefined {
+  const siteId = 'default'
+
+  const baseUrl = baseUrlForSite(siteId)
+  if (baseUrl) return { baseUrl, siteId }
+}
+
 export function getTenantFromEnv(): string | undefined {
   if (import.meta.env.SCRIVITO_TENANT) return import.meta.env.SCRIVITO_TENANT
 


### PR DESCRIPTION
Assumptions/constraints:
* Each site has a unique homepage `_language`
* If no site matches the current URL, the first site by language code is the fallback site
* The language prefix is always used, even if there is only one site
* The language detection ignores a multi-tenancy path prefix, no matter if multi-tenant or not

I.e. `<origin>/<tenantId>/<lang><path>` or `<origin>/<lang><path>`