### PR TITLE
baseUrl

### DIFF
--- a/src/Objs/Homepage/HomepageEditingConfig.ts
+++ b/src/Objs/Homepage/HomepageEditingConfig.ts
@@ -7,6 +7,11 @@ provideEditingConfig(Homepage, {
     contentTitle: {
       title: 'Site name',
     },
+    baseUrl: {
+      title: 'Base URL',
+      description:
+        'Under which URL is this site reachable? E.g. "https://www.tynacoon.com/en"',
+    },
     metaDataDescription: {
       title: 'Page description',
       description: 'Limit to 175, ideally 150 characters.',
@@ -37,6 +42,7 @@ provideEditingConfig(Homepage, {
       title: 'Site settings',
       properties: [
         'contentTitle',
+        'baseUrl',
         'siteLogoDark',
         'siteLogoLight',
         'siteFavicon',

--- a/src/Objs/Homepage/HomepageObjClass.ts
+++ b/src/Objs/Homepage/HomepageObjClass.ts
@@ -2,6 +2,7 @@ import { provideObjClass } from 'scrivito'
 
 export const Homepage = provideObjClass('Homepage', {
   attributes: {
+    baseUrl: 'stringlist',
     body: 'widgetlist',
     childOrder: 'referencelist',
     contentTitle: 'string',

--- a/src/config/scrivitoSites.ts
+++ b/src/config/scrivitoSites.ts
@@ -4,6 +4,7 @@ import { scrivitoTenantId, isMultitenancyEnabled } from './scrivitoTenants'
 const location = typeof window !== 'undefined' ? window.location : undefined
 
 const NEOLETTER_MAILINGS_SITE_ID = 'mailing-app'
+const SCRIVITO_PORTAL_APP_ROOT_CONTENT_ID = 'c2a0aab78be05a4e'
 
 export function baseUrlForSite(siteId: string): string | undefined {
   if (siteId === NEOLETTER_MAILINGS_SITE_ID) {
@@ -49,7 +50,9 @@ export function siteForUrl(
 export async function ensureSiteIsPresent() {
   if ((await load(currentSiteId)) === null) {
     navigateTo(() => {
-      const websites = allWebsites().toArray()
+      const websites = Obj.onAllSites()
+        .where('_contentId', 'equals', SCRIVITO_PORTAL_APP_ROOT_CONTENT_ID)
+        .toArray()
       const preferredLanguageOrder = [...window.navigator.languages, 'en', null]
 
       for (const language of preferredLanguageOrder) {

--- a/src/config/scrivitoSites.ts
+++ b/src/config/scrivitoSites.ts
@@ -11,6 +11,13 @@ export function baseUrlForSite(siteId: string): string | undefined {
     return `https://mailing.neoletter.com/${getInstanceId()}`
   }
 
+  const siteRoot = Obj.onSite(siteId).root()
+  if (siteRoot?.contentId() !== SCRIVITO_PORTAL_APP_ROOT_CONTENT_ID) {
+    const rawBaseUrl = siteRoot?.get('baseUrl')
+    const baseUrl = isStringArray(rawBaseUrl) ? rawBaseUrl[0] : undefined
+    return baseUrl ? baseUrl : undefined
+  }
+
   if (!location) return
 
   const urlParts = [location.origin]
@@ -18,7 +25,7 @@ export function baseUrlForSite(siteId: string): string | undefined {
 
   if (isMultitenancyEnabled()) urlParts.push(tenant)
 
-  const language = Obj.onSite(siteId).root()?.language()
+  const language = siteRoot?.language()
   if (language) urlParts.push(language)
 
   return urlParts.join('/')
@@ -72,4 +79,8 @@ function siteHasLanguage(site: Obj, language: string | null) {
   return language && siteLanguage
     ? language.startsWith(siteLanguage)
     : language === siteLanguage
+}
+
+function isStringArray(item: unknown): item is string[] {
+  return Array.isArray(item) && item.every((i) => typeof i === 'string')
 }

--- a/src/config/scrivitoSites.ts
+++ b/src/config/scrivitoSites.ts
@@ -38,7 +38,9 @@ export function siteForUrl(
   const language = /\b\/([0-9a-f]{32}\/)?(?<lang>[a-z]{2})([?/]|$)/.exec(url)
     ?.groups?.lang
 
-  const siteId = allWebsites()
+  const siteId = Obj.onAllSites()
+    .where('_path', 'equals', '/')
+    .andNot('_siteId', 'equals', NEOLETTER_MAILINGS_SITE_ID)
     .and('_language', 'equals', language || null)
     .first()
     ?.siteId()
@@ -63,12 +65,6 @@ export async function ensureSiteIsPresent() {
       return websites[0] || null
     })
   }
-}
-
-function allWebsites() {
-  return Obj.onAllSites()
-    .where('_path', 'equals', '/')
-    .andNot('_siteId', 'equals', NEOLETTER_MAILINGS_SITE_ID)
 }
 
 function siteHasLanguage(site: Obj, language: string | null) {


### PR DESCRIPTION
Other sites of the portal app are now detected by the same `_contentId`. Any other site is not considered for "automatically language selection".

Other sites can offer an optional `baseUrl` `stringlist` attribute in their root obj. This will be used by `baseUrlForSite()` and indirectly by `siteForUrl()`.

Optional content changes: https://edit.scrivito.com/d0a154d76edf2a7bd991fc658e700a1d~https://baseurl.scrivito-portal-app.pages.dev/en?_scrivito_workspace_id=ja01131102e76a48&_scrivito_display_mode=view

Please note, that the content is not required, but helps other applications such as neoletter to "link back".