### PR TITLE
Optimize baseUrlForSite and siteForUrl

### DIFF
--- a/src/config/scrivitoSites.ts
+++ b/src/config/scrivitoSites.ts
@@ -35,6 +35,23 @@ export function siteForUrl(
     return { baseUrl: neoletterBaseUrl, siteId: NEOLETTER_MAILINGS_SITE_ID }
   }
 
+  const baseAppUrl = getBaseAppUrl()
+  if (baseAppUrl && url.startsWith(baseAppUrl)) {
+    const regex = new RegExp(`^${baseAppUrl}\\/(?<lang>[a-z]{2})([?/]|$)`)
+    const language = regex.exec(url)?.groups?.lang
+    if (!language) return
+
+    const languageSite = allPortalWebsites()
+      .and('_language', 'equals', language)
+      .first()
+    if (!languageSite) return
+
+    const languageSiteId = languageSite.siteId()
+    if (!languageSiteId) return
+
+    return { baseUrl: `${baseAppUrl}/${language}`, siteId: languageSiteId }
+  }
+
   return Obj.onAllSites()
     .where('_path', 'equals', '/')
     .toArray()

--- a/src/config/scrivitoSites.ts
+++ b/src/config/scrivitoSites.ts
@@ -30,6 +30,11 @@ export function baseUrlForSite(siteId: string): string | undefined {
 export function siteForUrl(
   url: string,
 ): { baseUrl: string; siteId: string } | undefined {
+  const neoletterBaseUrl = `https://mailing.neoletter.com/${getInstanceId()}`
+  if (url.startsWith(neoletterBaseUrl)) {
+    return { baseUrl: neoletterBaseUrl, siteId: NEOLETTER_MAILINGS_SITE_ID }
+  }
+
   return Obj.onAllSites()
     .where('_path', 'equals', '/')
     .toArray()

--- a/src/config/scrivitoSites.ts
+++ b/src/config/scrivitoSites.ts
@@ -1,5 +1,5 @@
 import { Obj, currentSiteId, getInstanceId, load, navigateTo } from 'scrivito'
-import { scrivitoTenantId, isMultitenancyEnabled } from './scrivitoTenants'
+import { isMultitenancyEnabled } from './scrivitoTenants'
 
 const location = typeof window !== 'undefined' ? window.location : undefined
 
@@ -18,17 +18,13 @@ export function baseUrlForSite(siteId: string): string | undefined {
     return buildExternalBaseUrl(siteRoot)
   }
 
-  if (!location) return
-
-  const urlParts = [location.origin]
-  const tenant = scrivitoTenantId()
-
-  if (isMultitenancyEnabled()) urlParts.push(tenant)
+  const baseAppUrl = getBaseAppUrl()
+  if (!baseAppUrl) return
 
   const language = siteRoot.language()
-  if (language) urlParts.push(language)
+  if (!language) return
 
-  return urlParts.join('/')
+  return `${baseAppUrl}/${language}`
 }
 
 export function siteForUrl(
@@ -67,6 +63,14 @@ export async function ensureSiteIsPresent() {
       return websites[0] || null
     })
   }
+}
+
+function getBaseAppUrl(): string | undefined {
+  if (!location) return
+
+  return isMultitenancyEnabled()
+    ? `${location.origin}/${getInstanceId()}`
+    : location.origin
 }
 
 function buildExternalBaseUrl(siteRoot: Obj): string | undefined {

--- a/src/config/scrivitoSites.ts
+++ b/src/config/scrivitoSites.ts
@@ -54,6 +54,10 @@ export function siteForUrl(
 
   return Obj.onAllSites()
     .where('_path', 'equals', '/')
+    .andNot('_contentId', 'equals', [
+      SCRIVITO_PORTAL_APP_ROOT_CONTENT_ID,
+      NEOLETTER_MAILINGS_SITE_ID,
+    ])
     .toArray()
     .filter(
       (website): website is { siteId: () => string } & Obj =>

--- a/src/config/scrivitoSites.ts
+++ b/src/config/scrivitoSites.ts
@@ -12,10 +12,10 @@ export function baseUrlForSite(siteId: string): string | undefined {
   }
 
   const siteRoot = Obj.onSite(siteId).root()
-  if (siteRoot?.contentId() !== SCRIVITO_PORTAL_APP_ROOT_CONTENT_ID) {
-    const rawBaseUrl = siteRoot?.get('baseUrl')
-    const baseUrl = isStringArray(rawBaseUrl) ? rawBaseUrl[0] : undefined
-    return baseUrl ? baseUrl : undefined
+  if (!siteRoot) return
+
+  if (siteRoot.contentId() !== SCRIVITO_PORTAL_APP_ROOT_CONTENT_ID) {
+    return buildExternalBaseUrl(siteRoot)
   }
 
   if (!location) return
@@ -25,7 +25,7 @@ export function baseUrlForSite(siteId: string): string | undefined {
 
   if (isMultitenancyEnabled()) urlParts.push(tenant)
 
-  const language = siteRoot?.language()
+  const language = siteRoot.language()
   if (language) urlParts.push(language)
 
   return urlParts.join('/')
@@ -67,6 +67,16 @@ export async function ensureSiteIsPresent() {
       return websites[0] || null
     })
   }
+}
+
+function buildExternalBaseUrl(siteRoot: Obj): string | undefined {
+  const rawBaseUrl = siteRoot.get('baseUrl')
+  if (!isStringArray(rawBaseUrl)) return
+
+  const baseUrl = rawBaseUrl[0]
+  if (baseUrl === '') return
+
+  return baseUrl
 }
 
 function siteHasLanguage(site: Obj, language: string | null) {

--- a/src/config/scrivitoSites.ts
+++ b/src/config/scrivitoSites.ts
@@ -59,10 +59,10 @@ export function siteForUrl(
       (website): website is { siteId: () => string } & Obj =>
         !!website.siteId(),
     )
-    .map((websiteWithSiteId) => {
-      const siteId = websiteWithSiteId.siteId()
-      return { siteId, baseUrl: baseUrlForSite(siteId) }
-    })
+    .map((websiteWithSiteId) => ({
+      baseUrl: buildExternalBaseUrl(websiteWithSiteId),
+      siteId: websiteWithSiteId.siteId(),
+    }))
     .find(
       (item): item is { baseUrl: string; siteId: string } =>
         !!item.baseUrl && url.startsWith(item.baseUrl),

--- a/src/config/scrivitoSites.ts
+++ b/src/config/scrivitoSites.ts
@@ -50,9 +50,7 @@ export function siteForUrl(
 export async function ensureSiteIsPresent() {
   if ((await load(currentSiteId)) === null) {
     navigateTo(() => {
-      const websites = Obj.onAllSites()
-        .where('_contentId', 'equals', SCRIVITO_PORTAL_APP_ROOT_CONTENT_ID)
-        .toArray()
+      const websites = allPortalWebsites().toArray()
       const preferredLanguageOrder = [...window.navigator.languages, 'en', null]
 
       for (const language of preferredLanguageOrder) {
@@ -81,6 +79,12 @@ function buildExternalBaseUrl(siteRoot: Obj): string | undefined {
   if (baseUrl === '') return
 
   return baseUrl
+}
+
+function allPortalWebsites() {
+  return Obj.onAllSites()
+    .where('_path', 'equals', '/')
+    .and('_contentId', 'equals', SCRIVITO_PORTAL_APP_ROOT_CONTENT_ID)
 }
 
 function siteHasLanguage(site: Obj, language: string | null) {


### PR DESCRIPTION
Follow up of https://github.com/Scrivito/scrivito-portal-app/pull/388/.

Please note, that `siteForUrl` still loads potentially many other site objs, if the requested `url` does not match the current origin. If I'm not mistaken we can not avoid it, because the `baseUrl` in the content can also contain URLs with a `path`, e.g. a hypothetical `https://subdomain.tynacoon.com/en` or `https://subdomain.tynacoon.com/en`. So simply `.and('baseUrl', 'equals', (new URL(url)).origin)` would potentially match a different site.