### PR TITLE
Partly baseUrl

### DIFF
--- a/src/config/scrivitoSites.ts
+++ b/src/config/scrivitoSites.ts
@@ -1,10 +1,9 @@
 import { Obj, currentSiteId, getInstanceId, load, navigateTo } from 'scrivito'
-import { scrivitoTenantId, isMultitenancyEnabled } from './scrivitoTenants'
+import { isMultitenancyEnabled } from './scrivitoTenants'
 
 const location = typeof window !== 'undefined' ? window.location : undefined
 
 const NEOLETTER_MAILINGS_SITE_ID = 'mailing-app'
-const SCRIVITO_PORTAL_APP_ROOT_CONTENT_ID = 'c2a0aab78be05a4e'
 
 export function baseUrlForSite(siteId: string): string | undefined {
   if (siteId === NEOLETTER_MAILINGS_SITE_ID) {
@@ -46,9 +45,7 @@ export function siteForUrl(
 export async function ensureSiteIsPresent() {
   if ((await load(currentSiteId)) === null) {
     navigateTo(() => {
-      const websites = Obj.onAllSites()
-        .where('_contentId', 'equals', SCRIVITO_PORTAL_APP_ROOT_CONTENT_ID)
-        .toArray()
+      const websites = allWebsites().toArray()
       const preferredLanguageOrder = [...window.navigator.languages, 'en', null]
 
       for (const language of preferredLanguageOrder) {
@@ -67,6 +64,12 @@ function getBaseAppUrl(): string | undefined {
   return isMultitenancyEnabled()
     ? `${location.origin}/${getInstanceId()}`
     : location.origin
+}
+
+function allWebsites() {
+  return Obj.onAllSites()
+    .where('_path', 'equals', '/')
+    .andNot('_siteId', 'equals', NEOLETTER_MAILINGS_SITE_ID)
 }
 
 function siteHasLanguage(site: Obj, language: string | null) {

--- a/src/config/scrivitoSites.ts
+++ b/src/config/scrivitoSites.ts
@@ -14,17 +14,13 @@ export function baseUrlForSite(siteId: string): string | undefined {
   const siteRoot = Obj.onSite(siteId).root()
   if (!siteRoot) return
 
-  if (!location) return
+  const baseAppUrl = getBaseAppUrl()
+  if (!baseAppUrl) return
 
-  const urlParts = [location.origin]
-  const tenant = scrivitoTenantId()
+  const language = siteRoot.language()
+  if (!language) return
 
-  if (isMultitenancyEnabled()) urlParts.push(tenant)
-
-  const language = siteRoot?.language()
-  if (language) urlParts.push(language)
-
-  return urlParts.join('/')
+  return `${baseAppUrl}/${language}`
 }
 
 export function siteForUrl(
@@ -63,6 +59,14 @@ export async function ensureSiteIsPresent() {
       return websites[0] || null
     })
   }
+}
+
+function getBaseAppUrl(): string | undefined {
+  if (!location) return
+
+  return isMultitenancyEnabled()
+    ? `${location.origin}/${getInstanceId()}`
+    : location.origin
 }
 
 function siteHasLanguage(site: Obj, language: string | null) {

--- a/src/config/scrivitoSites.ts
+++ b/src/config/scrivitoSites.ts
@@ -12,11 +12,7 @@ export function baseUrlForSite(siteId: string): string | undefined {
   }
 
   const siteRoot = Obj.onSite(siteId).root()
-  if (siteRoot?.contentId() !== SCRIVITO_PORTAL_APP_ROOT_CONTENT_ID) {
-    const rawBaseUrl = siteRoot?.get('baseUrl')
-    const baseUrl = isStringArray(rawBaseUrl) ? rawBaseUrl[0] : undefined
-    return baseUrl ? baseUrl : undefined
-  }
+  if (!siteRoot) return
 
   if (!location) return
 
@@ -74,8 +70,4 @@ function siteHasLanguage(site: Obj, language: string | null) {
   return language && siteLanguage
     ? language.startsWith(siteLanguage)
     : language === siteLanguage
-}
-
-function isStringArray(item: unknown): item is string[] {
-  return Array.isArray(item) && item.every((i) => typeof i === 'string')
 }


### PR DESCRIPTION
Reverts `SCRIVITO_PORTAL_APP_ROOT_CONTENT_ID` and `baseUrl` attribute consideration in `scrivitoSites.ts` (as introduced in #388).

Also improves `siteForUrl`.

Closes #389, since this is a different approach to the issue (dropping the functionality).