### PR TITLE
Show loading indicator for data widgets

### DIFF
--- a/src/Components/Loading.tsx
+++ b/src/Components/Loading.tsx
@@ -2,15 +2,15 @@ import { connect } from 'scrivito'
 import { getCurrentLanguage } from '../utils/currentLanguage'
 
 export const Loading = connect(function Loading() {
+  const message = getMessage()
   return (
-    <div className="text-muted">
-      <span
-        className="spinner-border spinner-border-sm me-2"
-        role="status"
-        aria-hidden="true"
-      />
-      {getMessage()}
-    </div>
+    <div
+      aria-busy="true"
+      aria-valuetext={message}
+      className="loading-placeholder"
+      role="progressbar"
+      title={message}
+    />
   )
 })
 

--- a/src/Components/Loading.tsx
+++ b/src/Components/Loading.tsx
@@ -1,0 +1,24 @@
+import { connect } from 'scrivito'
+import { getCurrentLanguage } from '../utils/currentLanguage'
+
+export const Loading = connect(function Loading() {
+  return (
+    <div className="text-muted">
+      <span
+        className="spinner-border spinner-border-sm me-2"
+        role="status"
+        aria-hidden="true"
+      />
+      {getMessage()}
+    </div>
+  )
+})
+
+function getMessage(): string {
+  switch (getCurrentLanguage()) {
+    case 'de':
+      return 'Daten werden geladen…'
+    default:
+      return 'Loading data…'
+  }
+}

--- a/src/Widgets/DataColumnListWidget/DataColumnListWidgetComponent.tsx
+++ b/src/Widgets/DataColumnListWidget/DataColumnListWidgetComponent.tsx
@@ -3,31 +3,36 @@ import { DataColumnListWidget } from './DataColumnListWidgetClass'
 import { EditorNote } from '../../Components/EditorNote'
 import { useContext } from 'react'
 import { DataBatchContext } from '../../Components/DataBatchContext'
+import { Loading } from '../../Components/Loading'
 
-provideComponent(DataColumnListWidget, ({ widget }) => {
-  const dataScope = useData()
-  const { limit } = useContext(DataBatchContext)
+provideComponent(
+  DataColumnListWidget,
+  ({ widget }) => {
+    const dataScope = useData()
+    const { limit } = useContext(DataBatchContext)
 
-  if (dataScope.isEmpty()) {
-    return <EditorNote>The data column list is empty.</EditorNote>
-  }
+    if (dataScope.isEmpty()) {
+      return <EditorNote>The data column list is empty.</EditorNote>
+    }
 
-  const columnsCount = widget.get('columnsCount') || '2'
+    const columnsCount = widget.get('columnsCount') || '2'
 
-  return (
-    <div className={`row row-cols-1 row-cols-md-${columnsCount}`}>
-      {dataScope
-        .transform({ limit })
-        .take()
-        .map((dataItem) => (
-          <ContentTag
-            content={widget}
-            attribute="content"
-            className="col"
-            dataContext={dataItem}
-            key={dataItem.id()}
-          />
-        ))}
-    </div>
-  )
-})
+    return (
+      <div className={`row row-cols-1 row-cols-md-${columnsCount}`}>
+        {dataScope
+          .transform({ limit })
+          .take()
+          .map((dataItem) => (
+            <ContentTag
+              content={widget}
+              attribute="content"
+              className="col"
+              dataContext={dataItem}
+              key={dataItem.id()}
+            />
+          ))}
+      </div>
+    )
+  },
+  { loading: Loading },
+)

--- a/src/Widgets/DataEmptyWidget/DataEmptyWidgetComponent.tsx
+++ b/src/Widgets/DataEmptyWidget/DataEmptyWidgetComponent.tsx
@@ -7,22 +7,26 @@ import {
 } from 'scrivito'
 import { DataEmptyWidget } from './DataEmptyWidgetClass'
 
-provideComponent(DataEmptyWidget, ({ widget }) => {
-  const dataScope = useData()
+provideComponent(
+  DataEmptyWidget,
+  ({ widget }) => {
+    const dataScope = useData()
 
-  if (
-    dataScope.containsData() &&
-    !isInPlaceEditingActive() &&
-    !isComparisonActive()
-  ) {
-    return null
-  }
+    if (
+      dataScope.containsData() &&
+      !isInPlaceEditingActive() &&
+      !isComparisonActive()
+    ) {
+      return null
+    }
 
-  return (
-    <ContentTag
-      content={widget}
-      attribute="content"
-      className={dataScope.containsData() ? 'opacity-60' : null}
-    />
-  )
-})
+    return (
+      <ContentTag
+        content={widget}
+        attribute="content"
+        className={dataScope.containsData() ? 'opacity-60' : null}
+      />
+    )
+  },
+  { loading: () => null },
+)

--- a/src/Widgets/DataPersonCardWidget/DataPersonCardWidgetComponent.tsx
+++ b/src/Widgets/DataPersonCardWidget/DataPersonCardWidgetComponent.tsx
@@ -6,20 +6,25 @@ import { isDataBinary } from '../../utils/dataBinaryToUrl'
 import { DataPersonCardWidget } from './DataPersonCardWidgetClass'
 import { EditorNote } from '../../Components/EditorNote'
 import personCircle from '../../assets/images/person-circle.svg'
+import { Loading } from '../../Components/Loading'
 
-provideComponent(DataPersonCardWidget, () => {
-  const dataScope = useData()
+provideComponent(
+  DataPersonCardWidget,
+  () => {
+    const dataScope = useData()
 
-  if (dataScope.isEmpty()) return <EditorNote>Data is empty.</EditorNote>
+    if (dataScope.isEmpty()) return <EditorNote>Data is empty.</EditorNote>
 
-  return (
-    <>
-      {dataScope.take().map((dataItem) => (
-        <PersonCard dataItem={dataItem} key={dataItem.id()} />
-      ))}
-    </>
-  )
-})
+    return (
+      <>
+        {dataScope.take().map((dataItem) => (
+          <PersonCard dataItem={dataItem} key={dataItem.id()} />
+        ))}
+      </>
+    )
+  },
+  { loading: Loading },
+)
 
 const PersonCard = connect(function PersonCard({
   dataItem,

--- a/src/Widgets/DataWidget/DataWidgetComponent.tsx
+++ b/src/Widgets/DataWidget/DataWidgetComponent.tsx
@@ -3,29 +3,34 @@ import { DataWidget } from './DataWidgetClass'
 import { EditorNote } from '../../Components/EditorNote'
 import { useContext } from 'react'
 import { DataBatchContext } from '../../Components/DataBatchContext'
+import { Loading } from '../../Components/Loading'
 
-provideComponent(DataWidget, ({ widget }) => {
-  const dataScope = useData()
-  const { limit } = useContext(DataBatchContext)
+provideComponent(
+  DataWidget,
+  ({ widget }) => {
+    const dataScope = useData()
+    const { limit } = useContext(DataBatchContext)
 
-  if (dataScope.isEmpty()) {
-    return <EditorNote>Data is empty.</EditorNote>
-  }
+    if (dataScope.isEmpty()) {
+      return <EditorNote>Data is empty.</EditorNote>
+    }
 
-  return (
-    <>
-      {dataScope
-        .transform({ limit })
-        .take()
-        .map((dataItem) => (
-          <ContentTag
-            content={widget}
-            attribute="content"
-            className="col"
-            dataContext={dataItem}
-            key={dataItem.id()}
-          />
-        ))}
-    </>
-  )
-})
+    return (
+      <>
+        {dataScope
+          .transform({ limit })
+          .take()
+          .map((dataItem) => (
+            <ContentTag
+              content={widget}
+              attribute="content"
+              className="col"
+              dataContext={dataItem}
+              key={dataItem.id()}
+            />
+          ))}
+      </>
+    )
+  },
+  { loading: Loading },
+)


### PR DESCRIPTION
PR best viewed with whitespace off.

<img width="1028" alt="image" src="https://github.com/Scrivito/scrivito-portal-app/assets/986170/cb68ae94-0cef-40f9-bea6-ccd03701f57b">



The main purpose is to indicate temporary issues connecting to backends.

As far as I can see we don't have any means of detecting permanent issues, because both known error cases
* PisaSales backend not available (TypeError)
* Not authorized as a user (status 401)

are transparently handled (retried) by the SDK.

One way we could provide more info to the user could be a pessimistic guess:
Add a timeout to the loader component and switch to some form of "Sorry, try again later" message.