### PR TITLE
DataPersonCard: Calculate user differently

### DIFF
--- a/src/Widgets/DataPersonCardWidget/DataPersonCardWidgetClass.ts
+++ b/src/Widgets/DataPersonCardWidget/DataPersonCardWidgetClass.ts
@@ -2,6 +2,7 @@ import { provideWidgetClass } from 'scrivito'
 
 export const DataPersonCardWidget = provideWidgetClass('DataPersonCardWidget', {
   attributes: {
-    data: 'datalocator',
+    attributeName: 'string',
+    headline: 'string',
   },
 })

--- a/src/Widgets/DataPersonCardWidget/DataPersonCardWidgetClass.ts
+++ b/src/Widgets/DataPersonCardWidget/DataPersonCardWidgetClass.ts
@@ -2,7 +2,7 @@ import { provideWidgetClass } from 'scrivito'
 
 export const DataPersonCardWidget = provideWidgetClass('DataPersonCardWidget', {
   attributes: {
-    attributeName: 'string',
+    data: 'datalocator',
     headline: 'string',
   },
 })

--- a/src/Widgets/DataPersonCardWidget/DataPersonCardWidgetComponent.tsx
+++ b/src/Widgets/DataPersonCardWidget/DataPersonCardWidgetComponent.tsx
@@ -1,4 +1,4 @@
-import { connect, DataItem, provideComponent, useData } from 'scrivito'
+import { connect, ContentTag, DataItem, provideComponent } from 'scrivito'
 
 import { DataBinaryImage } from '../../Components/DataBinaryImage'
 import { ensureString } from '../../utils/ensureString'
@@ -6,18 +6,31 @@ import { isDataBinary } from '../../utils/dataBinaryToUrl'
 import { DataPersonCardWidget } from './DataPersonCardWidgetClass'
 import { EditorNote } from '../../Components/EditorNote'
 import personCircle from '../../assets/images/person-circle.svg'
+import { CurrentUser } from '../../Data/CurrentUser/CurrentUserDataItem'
+import { User } from '../../Data/User/UserDataClass'
 
-provideComponent(DataPersonCardWidget, () => {
-  const dataScope = useData()
+provideComponent(DataPersonCardWidget, ({ widget }) => {
+  // TODO: Remove workaround, once #10883 is resolved
+  const name = ensureString(widget.get('attributeName'))
+  if (!name) return <EditorNote>Data is empty.</EditorNote>
 
-  if (dataScope.isEmpty()) return <EditorNote>Data is empty.</EditorNote>
+  const value = CurrentUser.get(name)
+  if (!value) return <EditorNote>Data is empty.</EditorNote>
+
+  // @ts-expect-error until out of private beta
+  const user: DataItem | null = User.get(value)
+
+  if (!user) return <EditorNote>Data is empty.</EditorNote>
 
   return (
-    <>
-      {dataScope.take().map((dataItem) => (
-        <PersonCard dataItem={dataItem} key={dataItem.id()} />
-      ))}
-    </>
+    <div>
+      <ContentTag
+        content={widget}
+        attribute="headline"
+        className="h6 text-uppercase"
+      />
+      <PersonCard dataItem={user} key={user.id()} />
+    </div>
   )
 })
 

--- a/src/Widgets/DataPersonCardWidget/DataPersonCardWidgetComponent.tsx
+++ b/src/Widgets/DataPersonCardWidget/DataPersonCardWidgetComponent.tsx
@@ -1,4 +1,10 @@
-import { connect, ContentTag, DataItem, provideComponent } from 'scrivito'
+import {
+  connect,
+  ContentTag,
+  DataItem,
+  provideComponent,
+  useDataLocator,
+} from 'scrivito'
 
 import { DataBinaryImage } from '../../Components/DataBinaryImage'
 import { ensureString } from '../../utils/ensureString'
@@ -6,24 +12,15 @@ import { isDataBinary } from '../../utils/dataBinaryToUrl'
 import { DataPersonCardWidget } from './DataPersonCardWidgetClass'
 import { EditorNote } from '../../Components/EditorNote'
 import personCircle from '../../assets/images/person-circle.svg'
-import { CurrentUser } from '../../Data/CurrentUser/CurrentUserDataItem'
-import { User } from '../../Data/User/UserDataClass'
 import { Loading } from '../../Components/Loading'
 
 provideComponent(
   DataPersonCardWidget,
   ({ widget }) => {
-    // TODO: Remove workaround, once #10883 is resolved
-    const name = ensureString(widget.get('attributeName'))
-    if (!name) return <EditorNote>Data is empty.</EditorNote>
+    // TODO: Replace with useData() once 1.41.0-rc2 is used
+    const dataScope = useDataLocator(widget.get('data'))
 
-    const value = CurrentUser.get(name)
-    if (!value) return <EditorNote>Data is empty.</EditorNote>
-
-    // @ts-expect-error until out of private beta
-    const user: DataItem | null = User.get(value)
-
-    if (!user) return <EditorNote>Data is empty.</EditorNote>
+    if (dataScope.isEmpty()) return <EditorNote>Data is empty.</EditorNote>
 
     return (
       <div>
@@ -32,7 +29,9 @@ provideComponent(
           attribute="headline"
           className="h6 text-uppercase"
         />
-        <PersonCard dataItem={user} key={user.id()} />
+        {dataScope.take().map((dataItem) => (
+          <PersonCard dataItem={dataItem} key={dataItem.id()} />
+        ))}
       </div>
     )
   },

--- a/src/Widgets/DataPersonCardWidget/DataPersonCardWidgetEditingConfig.ts
+++ b/src/Widgets/DataPersonCardWidget/DataPersonCardWidgetEditingConfig.ts
@@ -5,4 +5,8 @@ import Thumbnail from './thumbnail.svg'
 provideEditingConfig(DataPersonCardWidget, {
   title: 'Data Person Card',
   thumbnail: Thumbnail,
+  properties: ['attributeName', 'headline'],
+  initialContent: {
+    headline: 'Your...',
+  },
 })

--- a/src/Widgets/DataPersonCardWidget/DataPersonCardWidgetEditingConfig.ts
+++ b/src/Widgets/DataPersonCardWidget/DataPersonCardWidgetEditingConfig.ts
@@ -5,7 +5,7 @@ import Thumbnail from './thumbnail.svg'
 provideEditingConfig(DataPersonCardWidget, {
   title: 'Data Person Card',
   thumbnail: Thumbnail,
-  properties: ['attributeName', 'headline'],
+  properties: ['headline'],
   initialContent: {
     headline: 'Your...',
   },


### PR DESCRIPTION
This also has the advantage that no headline is shown, if the user could not be found.

Needs content: https://edit.scrivito.com/d0a154d76edf2a7bd991fc658e700a1d~https://workaround-datapersoncardwid.scrivito-portal-app.pages.dev/en/my-tynacoon?_scrivito_workspace_id=je9ba13d7a074d63&_scrivito_display_mode=view