### PR TITLE
SearchResultsWidget shows loader for "results count"

### DIFF
--- a/src/Widgets/SearchResultsWidget/SearchResultsWidgetClass.ts
+++ b/src/Widgets/SearchResultsWidget/SearchResultsWidgetClass.ts
@@ -6,6 +6,7 @@ export const SearchResultsWidget = provideWidgetClass('SearchResultsWidget', {
     resultsHeadline: 'string',
     resultsHeadline0: 'string',
     resultsHeadline1: 'string',
+    resultsLoadingHeadline: 'string',
     searchButtonLabel: 'string',
     searchInputPlaceholder: 'string',
     showMoreResultsLabel: 'string',

--- a/src/Widgets/SearchResultsWidget/SearchResultsWidgetComponent.tsx
+++ b/src/Widgets/SearchResultsWidget/SearchResultsWidgetComponent.tsx
@@ -176,5 +176,9 @@ const TotalCountSummary = connect(
       />
     )
   },
-  { loading: Loading },
+  {
+    loading: ({ widget }: { widget: SearchResultsWidgetInstance }) => (
+      <ContentTag content={widget} attribute="resultsLoadingHeadline" />
+    ),
+  },
 )

--- a/src/Widgets/SearchResultsWidget/SearchResultsWidgetComponent.tsx
+++ b/src/Widgets/SearchResultsWidget/SearchResultsWidgetComponent.tsx
@@ -86,14 +86,16 @@ provideComponent(SearchResultsWidget, ({ widget }) => {
         </div>
       </section>
 
-      <SearchResults
-        search={search}
-        query={query}
-        maxItems={maxItems}
-        setMaxItems={setMaxItems}
-        readMoreLabel={readMoreLabel}
-        showMoreResultsLabel={showMoreResultsLabel}
-      />
+      <section className="bg-white py-3">
+        <SearchResults
+          search={search}
+          query={query}
+          maxItems={maxItems}
+          setMaxItems={setMaxItems}
+          readMoreLabel={readMoreLabel}
+          showMoreResultsLabel={showMoreResultsLabel}
+        />
+      </section>
     </InPlaceEditingOff>
   )
 })
@@ -117,40 +119,36 @@ const SearchResults = connect(
     const searchResults = search.take(maxItems)
 
     return (
-      <section className="bg-white py-3">
-        <div className="container">
-          {searchResults.map((searchResult) => (
-            <SearchResult
-              key={`search-result-${searchResult.id()}`}
-              query={query}
-              readMoreLabel={readMoreLabel}
-              searchResult={searchResult}
-            />
-          ))}
-          {search.count() > maxItems ? (
-            <div className="text-center">
-              <button
-                className="btn btn-outline-primary"
-                onClick={(e) => {
-                  e.preventDefault()
-                  setMaxItems((maxItems) => maxItems + 10)
-                }}
-              >
-                {showMoreResultsLabel}
-              </button>
-            </div>
-          ) : null}
-        </div>
-      </section>
+      <div className="container">
+        {searchResults.map((searchResult) => (
+          <SearchResult
+            key={`search-result-${searchResult.id()}`}
+            query={query}
+            readMoreLabel={readMoreLabel}
+            searchResult={searchResult}
+          />
+        ))}
+        {search.count() > maxItems ? (
+          <div className="text-center">
+            <button
+              className="btn btn-outline-primary"
+              onClick={(e) => {
+                e.preventDefault()
+                setMaxItems((maxItems) => maxItems + 10)
+              }}
+            >
+              {showMoreResultsLabel}
+            </button>
+          </div>
+        ) : null}
+      </div>
     )
   },
   {
     loading: () => (
-      <section className="bg-white py-3">
-        <div className="container text-center">
-          <Loading />
-        </div>
-      </section>
+      <div className="container text-center">
+        <Loading />
+      </div>
     ),
   },
 )

--- a/src/Widgets/SearchResultsWidget/SearchResultsWidgetComponent.tsx
+++ b/src/Widgets/SearchResultsWidget/SearchResultsWidgetComponent.tsx
@@ -38,8 +38,6 @@ provideComponent(SearchResultsWidget, ({ widget }) => {
     .and('_dataParam', 'equals', null) // Ignore data details pages
     .andNot('excludeFromSearch', 'equals', true)
 
-  const searchResults = search.take(maxItems)
-
   const readMoreLabel = widget.get('readMoreLabel')
   const searchButtonLabel = widget.get('searchButtonLabel')
   const searchInputPlaceholder = widget.get('searchInputPlaceholder')
@@ -88,32 +86,61 @@ provideComponent(SearchResultsWidget, ({ widget }) => {
         </div>
       </section>
 
-      <section className="bg-white py-3">
-        <div className="container">
-          {searchResults.map((searchResult) => (
-            <SearchResult
-              key={`search-result-${searchResult.id()}`}
-              query={query}
-              readMoreLabel={readMoreLabel}
-              searchResult={searchResult}
-            />
-          ))}
-          {search.count() > maxItems ? (
-            <div className="text-center">
-              <button
-                className="btn btn-outline-primary"
-                onClick={(e) => {
-                  e.preventDefault()
-                  setMaxItems((maxItems) => maxItems + 10)
-                }}
-              >
-                {showMoreResultsLabel}
-              </button>
-            </div>
-          ) : null}
-        </div>
-      </section>
+      <SearchResults
+        search={search}
+        query={query}
+        maxItems={maxItems}
+        setMaxItems={setMaxItems}
+        readMoreLabel={readMoreLabel}
+        showMoreResultsLabel={showMoreResultsLabel}
+      />
     </InPlaceEditingOff>
+  )
+})
+
+const SearchResults = connect(function SearchResults({
+  search,
+  query,
+  maxItems,
+  setMaxItems,
+  readMoreLabel,
+  showMoreResultsLabel,
+}: {
+  search: ObjSearch
+  query: string
+  maxItems: number
+  setMaxItems: React.Dispatch<React.SetStateAction<number>>
+  readMoreLabel: string
+  showMoreResultsLabel: string
+}) {
+  const searchResults = search.take(maxItems)
+
+  return (
+    <section className="bg-white py-3">
+      <div className="container">
+        {searchResults.map((searchResult) => (
+          <SearchResult
+            key={`search-result-${searchResult.id()}`}
+            query={query}
+            readMoreLabel={readMoreLabel}
+            searchResult={searchResult}
+          />
+        ))}
+        {search.count() > maxItems ? (
+          <div className="text-center">
+            <button
+              className="btn btn-outline-primary"
+              onClick={(e) => {
+                e.preventDefault()
+                setMaxItems((maxItems) => maxItems + 10)
+              }}
+            >
+              {showMoreResultsLabel}
+            </button>
+          </div>
+        ) : null}
+      </div>
+    </section>
   )
 })
 

--- a/src/Widgets/SearchResultsWidget/SearchResultsWidgetComponent.tsx
+++ b/src/Widgets/SearchResultsWidget/SearchResultsWidgetComponent.tsx
@@ -6,6 +6,7 @@ import {
   InPlaceEditingOff,
   navigateTo,
   Obj,
+  ObjSearch,
   provideComponent,
 } from 'scrivito'
 import { useRef, useState } from 'react'
@@ -16,6 +17,7 @@ import {
   SearchResultsWidgetInstance,
 } from './SearchResultsWidgetClass'
 import { DATA_OBJ_CLASSES } from '../../Objs/dataObjClasses'
+import { Loading } from '../../Components/Loading'
 
 const BLACKLIST_OBJ_CLASSES = [
   'Image',
@@ -37,7 +39,6 @@ provideComponent(SearchResultsWidget, ({ widget }) => {
     .andNot('excludeFromSearch', 'equals', true)
 
   const searchResults = search.take(maxItems)
-  const totalCount = search.count()
 
   const readMoreLabel = widget.get('readMoreLabel')
   const searchButtonLabel = widget.get('searchButtonLabel')
@@ -82,7 +83,7 @@ provideComponent(SearchResultsWidget, ({ widget }) => {
           </form>
 
           <h1 className="h3 b-bottom text-center mt-3">
-            <TotalCountSummary totalCount={totalCount} widget={widget} />
+            <TotalCountSummary search={search} widget={widget} />
           </h1>
         </div>
       </section>
@@ -97,7 +98,7 @@ provideComponent(SearchResultsWidget, ({ widget }) => {
               searchResult={searchResult}
             />
           ))}
-          {totalCount > maxItems ? (
+          {search.count() > maxItems ? (
             <div className="text-center">
               <button
                 className="btn btn-outline-primary"
@@ -116,22 +117,26 @@ provideComponent(SearchResultsWidget, ({ widget }) => {
   )
 })
 
-const TotalCountSummary = connect(function TotalCountSummary({
-  totalCount,
-  widget,
-}: {
-  totalCount: number
-  widget: SearchResultsWidgetInstance
-}) {
-  const attributes = ['resultsHeadline0', 'resultsHeadline1'] as const
-  const attribute = attributes[totalCount] || 'resultsHeadline'
+const TotalCountSummary = connect(
+  function TotalCountSummary({
+    search,
+    widget,
+  }: {
+    search: ObjSearch
+    widget: SearchResultsWidgetInstance
+  }) {
+    const totalCount = search.count()
+    const attributes = ['resultsHeadline0', 'resultsHeadline1'] as const
+    const attribute = attributes[totalCount] || 'resultsHeadline'
 
-  return (
-    <ContentTag
-      tag="span"
-      content={widget}
-      attribute={attribute}
-      dataContext={{ count: totalCount.toString() }}
-    />
-  )
-})
+    return (
+      <ContentTag
+        tag="span"
+        content={widget}
+        attribute={attribute}
+        dataContext={{ count: totalCount.toString() }}
+      />
+    )
+  },
+  { loading: Loading },
+)

--- a/src/Widgets/SearchResultsWidget/SearchResultsWidgetComponent.tsx
+++ b/src/Widgets/SearchResultsWidget/SearchResultsWidgetComponent.tsx
@@ -98,51 +98,62 @@ provideComponent(SearchResultsWidget, ({ widget }) => {
   )
 })
 
-const SearchResults = connect(function SearchResults({
-  search,
-  query,
-  maxItems,
-  setMaxItems,
-  readMoreLabel,
-  showMoreResultsLabel,
-}: {
-  search: ObjSearch
-  query: string
-  maxItems: number
-  setMaxItems: React.Dispatch<React.SetStateAction<number>>
-  readMoreLabel: string
-  showMoreResultsLabel: string
-}) {
-  const searchResults = search.take(maxItems)
+const SearchResults = connect(
+  function SearchResults({
+    search,
+    query,
+    maxItems,
+    setMaxItems,
+    readMoreLabel,
+    showMoreResultsLabel,
+  }: {
+    search: ObjSearch
+    query: string
+    maxItems: number
+    setMaxItems: React.Dispatch<React.SetStateAction<number>>
+    readMoreLabel: string
+    showMoreResultsLabel: string
+  }) {
+    const searchResults = search.take(maxItems)
 
-  return (
-    <section className="bg-white py-3">
-      <div className="container">
-        {searchResults.map((searchResult) => (
-          <SearchResult
-            key={`search-result-${searchResult.id()}`}
-            query={query}
-            readMoreLabel={readMoreLabel}
-            searchResult={searchResult}
-          />
-        ))}
-        {search.count() > maxItems ? (
-          <div className="text-center">
-            <button
-              className="btn btn-outline-primary"
-              onClick={(e) => {
-                e.preventDefault()
-                setMaxItems((maxItems) => maxItems + 10)
-              }}
-            >
-              {showMoreResultsLabel}
-            </button>
-          </div>
-        ) : null}
-      </div>
-    </section>
-  )
-})
+    return (
+      <section className="bg-white py-3">
+        <div className="container">
+          {searchResults.map((searchResult) => (
+            <SearchResult
+              key={`search-result-${searchResult.id()}`}
+              query={query}
+              readMoreLabel={readMoreLabel}
+              searchResult={searchResult}
+            />
+          ))}
+          {search.count() > maxItems ? (
+            <div className="text-center">
+              <button
+                className="btn btn-outline-primary"
+                onClick={(e) => {
+                  e.preventDefault()
+                  setMaxItems((maxItems) => maxItems + 10)
+                }}
+              >
+                {showMoreResultsLabel}
+              </button>
+            </div>
+          ) : null}
+        </div>
+      </section>
+    )
+  },
+  {
+    loading: () => (
+      <section className="bg-white py-3">
+        <div className="container text-center">
+          <Loading />
+        </div>
+      </section>
+    ),
+  },
+)
 
 const TotalCountSummary = connect(
   function TotalCountSummary({

--- a/src/Widgets/SearchResultsWidget/SearchResultsWidgetComponent.tsx
+++ b/src/Widgets/SearchResultsWidget/SearchResultsWidgetComponent.tsx
@@ -167,7 +167,6 @@ const TotalCountSummary = connect(
 
     return (
       <ContentTag
-        tag="span"
         content={widget}
         attribute={attribute}
         dataContext={{ count: totalCount.toString() }}

--- a/src/Widgets/SearchResultsWidget/SearchResultsWidgetEditingConfig.ts
+++ b/src/Widgets/SearchResultsWidget/SearchResultsWidgetEditingConfig.ts
@@ -7,6 +7,7 @@ provideEditingConfig(SearchResultsWidget, {
   thumbnail: Thumbnail,
   attributes: {
     readMoreLabel: { title: 'Read-more buttons label' },
+    resultsLoadingHeadline: { title: 'Headline for loading results' },
     resultsHeadline0: { title: 'Headline for 0 results' },
     resultsHeadline1: { title: 'Headline for 1 result' },
     resultsHeadline: {
@@ -24,6 +25,7 @@ provideEditingConfig(SearchResultsWidget, {
     'topBannerBackground',
     'searchInputPlaceholder',
     'searchButtonLabel',
+    'resultsLoadingHeadline',
     'resultsHeadline0',
     'resultsHeadline1',
     'resultsHeadline',
@@ -35,6 +37,7 @@ provideEditingConfig(SearchResultsWidget, {
     resultsHeadline: '__count__ search results',
     resultsHeadline0: 'No search results',
     resultsHeadline1: '1 search result',
+    resultsLoadingHeadline: 'Search results',
     searchButtonLabel: 'Search again',
     searchInputPlaceholder: 'Search',
     showMoreResultsLabel: 'Load more',

--- a/src/Widgets/SearchResultsWidget/SearchResultsWidgetEditingConfig.ts
+++ b/src/Widgets/SearchResultsWidget/SearchResultsWidgetEditingConfig.ts
@@ -7,7 +7,7 @@ provideEditingConfig(SearchResultsWidget, {
   thumbnail: Thumbnail,
   attributes: {
     readMoreLabel: { title: 'Read-more buttons label' },
-    resultsLoadingHeadline: { title: 'Headline for loading results' },
+    resultsLoadingHeadline: { title: 'Headline while loading results' },
     resultsHeadline0: { title: 'Headline for 0 results' },
     resultsHeadline1: { title: 'Headline for 1 result' },
     resultsHeadline: {


### PR DESCRIPTION
For that the loading of "search.count()" had to move to "TotalCountSummary"

Needs content: https://edit.scrivito.com/d0a154d76edf2a7bd991fc658e700a1d~https://more-loading.scrivito-portal-app.pages.dev/en/search-results?q=Foo&_scrivito_workspace_id=k05aba3b533fa47f&_scrivito_display_mode=view