### PR TITLE
Enable hyphens to break words

### DIFF
--- a/src/assets/stylesheets/index.scss
+++ b/src/assets/stylesheets/index.scss
@@ -71,6 +71,8 @@
   --bs-link-hover-color-rgb: 10, 88, 202;
   --bs-code-color: #d63384;
   --bs-highlight-bg: #fff3cd;
+
+  hyphens: auto;
 }
 
 .btn {
@@ -1626,7 +1628,6 @@ header .navbar.navbar-expand-lg {
   margin: 0;
   color: var(--bs-nav-link-color);
   display: flex;
-  word-break: break-all;
 }
 
 .nav-bordered li.active > a {


### PR DESCRIPTION
Enables ` hyphens: auto` for all text. This way the navigation will not strangely "wrap".

Before: 
![scrivito-portal-app pages dev_de_abonnements-40fcff128372c95a(iPad Pro) before](https://github.com/Scrivito/scrivito-portal-app/assets/86275/c671bdc1-2d14-470b-b656-ea0b5652a482)

After:
![hyphens scrivito-portal-app pages dev_de_mein-tynacoon-bd53fa4ef38c1c40(iPad Pro) after](https://github.com/Scrivito/scrivito-portal-app/assets/86275/3571053f-a9a2-47f1-a860-0eceb6c41842)


Live-Preview: https://hyphens.scrivito-portal-app.pages.dev/en