### PR TITLE
Only redirect in the app, not in extensions

### DIFF
--- a/src/config/scrivito.ts
+++ b/src/config/scrivito.ts
@@ -1,9 +1,5 @@
 import { configure } from 'scrivito'
-import {
-  baseUrlForSite,
-  ensureSiteIsPresent,
-  siteForUrl,
-} from './scrivitoSites'
+import { baseUrlForSite, siteForUrl } from './scrivitoSites'
 import { scrivitoTenantId } from './scrivitoTenants'
 
 export function configureScrivito() {
@@ -26,6 +22,4 @@ export function configureScrivito() {
       assetUrlBase: '/scrivito',
     },
   })
-
-  ensureSiteIsPresent()
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -7,8 +7,10 @@ import './Objs'
 import './Widgets'
 import { App } from './App'
 import { configure } from './config'
+import { ensureSiteIsPresent } from './config/scrivitoSites'
 
 configure()
+ensureSiteIsPresent()
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>


### PR DESCRIPTION
Navigating inside Scrivito Extensions may break them for the latest Scrivito version.