### PR TITLE
Enforce passing a dependency array to useEffect

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,6 +1,7 @@
 {
   "extends": [
     "eslint:recommended",
+    "plugin:@arabasta/require-useeffect-dependency-array/recommended-legacy",
     "plugin:@typescript-eslint/recommended",
     "plugin:react/recommended",
     "plugin:react/jsx-runtime",

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "vite-node": "^1.6.0"
       },
       "devDependencies": {
+        "@arabasta/eslint-plugin-require-useeffect-dependency-array": "^1.0.9",
         "@cloudflare/workers-types": "^4.20240529.0",
         "@types/highlight-words-core": "^1.2.3",
         "@types/lodash-es": "^4.17.12",
@@ -54,6 +55,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@arabasta/eslint-plugin-require-useeffect-dependency-array": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@arabasta/eslint-plugin-require-useeffect-dependency-array/-/eslint-plugin-require-useeffect-dependency-array-1.0.9.tgz",
+      "integrity": "sha512-yto2hiAL6KC2xPvZU1CqJQlZWUNrTuOa86fw5BygwWBURqL99uilVuVa82CgvOSWcT1STrp/WBYz0dKHPdJ7Rw==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "eslint": ">=8.0.0"
       }
     },
     "node_modules/@babel/runtime": {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "vite-node": "^1.6.0"
   },
   "devDependencies": {
+    "@arabasta/eslint-plugin-require-useeffect-dependency-array": "^1.0.9",
     "@cloudflare/workers-types": "^4.20240529.0",
     "@types/highlight-words-core": "^1.2.3",
     "@types/lodash-es": "^4.17.12",

--- a/src/Components/DataBinaryImage.tsx
+++ b/src/Components/DataBinaryImage.tsx
@@ -13,7 +13,7 @@ export function DataBinaryImage({
   const [src, setSrc] = useState<string | undefined>(undefined)
   useEffect(() => {
     dataBinaryToUrl(dataBinary).then(({ url }) => setSrc(url))
-  }, [dataBinary]) // TODO: Find out, why "eslint-plugin-react-hooks" does not detect this!
+  }, [dataBinary])
 
   if (!src) return null
   return <img src={src} alt={alt} className={className} />


### PR DESCRIPTION
https://www.npmjs.com/package/@arabasta/eslint-plugin-require-useeffect-dependency-array

This takes away one degree of freedom but
this is virtually never used and most likely an error. See, for example, #264.

Feel free to close if the added complexity is not worth it. The endless loop was a logic mistake in the first place and there's no reliable way to prevent it. We always executed the effect (no dependency array) and always set a state in the callback.