### PR TITLE
DataLabelWidget: Format numbers language aware

### DIFF
--- a/src/Widgets/DataLabelWidget/DataLabelWidgetComponent.tsx
+++ b/src/Widgets/DataLabelWidget/DataLabelWidgetComponent.tsx
@@ -69,6 +69,10 @@ const AttributeValue = connect(function AttributeValue({
   }
   if (showAs === 'link') return <Link value={attributeValue} />
 
+  if (typeof attributeValue === 'number') {
+    return <NumberText value={attributeValue} />
+  }
+
   const value = localizeAttributeValue({
     dataClass: dataItemAttribute.dataClass(),
     attributeName: dataItemAttribute.attributeName(),
@@ -80,6 +84,10 @@ const AttributeValue = connect(function AttributeValue({
 
 function Text({ value }: { value: unknown }) {
   return value ? value.toString() : localizeNotAvailable()
+}
+
+function NumberText({ value }: { value: number }) {
+  return new Intl.NumberFormat(getCurrentLanguage()).format(value)
 }
 
 const Currency = connect(function Currency({ value }: { value: unknown }) {

--- a/src/Widgets/DataLabelWidget/DataLabelWidgetComponent.tsx
+++ b/src/Widgets/DataLabelWidget/DataLabelWidgetComponent.tsx
@@ -86,9 +86,9 @@ function Text({ value }: { value: unknown }) {
   return value ? value.toString() : localizeNotAvailable()
 }
 
-function NumberText({ value }: { value: number }) {
+const NumberText = connect(function NumberText({ value }: { value: number }) {
   return new Intl.NumberFormat(getCurrentLanguage()).format(value)
-}
+})
 
 const Currency = connect(function Currency({ value }: { value: unknown }) {
   if (value === null) return localizeNotAvailable()

--- a/src/Widgets/DataLabelWidget/DataLabelWidgetComponent.tsx
+++ b/src/Widgets/DataLabelWidget/DataLabelWidgetComponent.tsx
@@ -87,7 +87,9 @@ function Text({ value }: { value: unknown }) {
 }
 
 const NumberText = connect(function NumberText({ value }: { value: number }) {
-  return new Intl.NumberFormat(getCurrentLanguage()).format(value)
+  return new Intl.NumberFormat(getCurrentLanguage(), {
+    useGrouping: Math.abs(value) >= 10000, // same as newer 'min2' option
+  }).format(value)
 })
 
 const Currency = connect(function Currency({ value }: { value: unknown }) {


### PR DESCRIPTION
Formats a numbers attribute according to the language of a site. To test you could use the `size` attribute of a Document.