### PR TITLE
Pisa url from content

### DIFF
--- a/src/Data/pisaClient.ts
+++ b/src/Data/pisaClient.ts
@@ -1,7 +1,7 @@
 import { createRestApiClient, currentLanguage, load } from 'scrivito'
 import { ensureString } from '../utils/ensureString'
 
-export function pisaUrl(): string {
+export async function pisaUrl(): Promise<string> {
   const url = ensureString(import.meta.env.PISA_URL)
   if (!url) throw new Error('PISA_URL is not set!')
 
@@ -9,7 +9,7 @@ export function pisaUrl(): string {
 }
 
 export async function pisaClient(subPath: string) {
-  const url = `${pisaUrl()}/${subPath}`
+  const url = `${await pisaUrl()}/${subPath}`
 
   const language = await load(() => currentLanguage() ?? 'en')
   const headers = { 'Accept-Language': language }

--- a/src/Data/pisaClient.ts
+++ b/src/Data/pisaClient.ts
@@ -1,9 +1,15 @@
-import { createRestApiClient, currentLanguage, load } from 'scrivito'
-import { ensureString } from '../utils/ensureString'
+import { Obj, createRestApiClient, currentLanguage, load } from 'scrivito'
+import { isHomepage } from '../Objs/Homepage/HomepageObjClass'
 
 export async function pisaUrl(): Promise<string> {
-  const url = ensureString(import.meta.env.PISA_URL)
-  if (!url) throw new Error('PISA_URL is not set!')
+  const defaultRoot = await load(() => Obj.onSite('default').root())
+  if (!isHomepage(defaultRoot)) return never()
+
+  const url = defaultRoot.get('pisaUrl')
+  if (!url) {
+    console.log('Please configure a pisaUrl on the default homepage.')
+    return never()
+  }
 
   return url
 }
@@ -15,4 +21,8 @@ export async function pisaClient(subPath: string) {
   const headers = { 'Accept-Language': language }
 
   return createRestApiClient(url, { headers })
+}
+
+function never() {
+  return new Promise<never>(() => {})
 }

--- a/src/Objs/Homepage/HomepageEditingConfig.ts
+++ b/src/Objs/Homepage/HomepageEditingConfig.ts
@@ -16,6 +16,11 @@ provideEditingConfig(Homepage, {
       title: 'Page description',
       description: 'Limit to 175, ideally 150 characters.',
     },
+    pisaUrl: {
+      title: 'PisaSales Portal API URL',
+      description:
+        'Only editable on the default site. Reload the app after changing this value.',
+    },
     siteLanguageIcon: { title: 'Language icon' },
     siteLogoDark: {
       title: 'Dark logo',
@@ -37,12 +42,13 @@ provideEditingConfig(Homepage, {
     },
     siteUserProfilePage: { title: 'Location of user profile page' },
   },
-  propertiesGroups: [
+  propertiesGroups: (site) => [
     {
       title: 'Site settings',
       properties: [
         'contentTitle',
         'baseUrl',
+        ['pisaUrl', { enabled: site.siteId() === 'default' }],
         'siteLogoDark',
         'siteLogoLight',
         'siteFavicon',

--- a/src/Objs/Homepage/HomepageEditingConfig.ts
+++ b/src/Objs/Homepage/HomepageEditingConfig.ts
@@ -18,7 +18,6 @@ provideEditingConfig(Homepage, {
     },
     pisaUrl: {
       title: 'PisaSales Portal API URL',
-      description: 'Only editable on the default site.',
     },
     siteLanguageIcon: { title: 'Language icon' },
     siteLogoDark: {
@@ -47,7 +46,7 @@ provideEditingConfig(Homepage, {
       properties: [
         'contentTitle',
         'baseUrl',
-        ['pisaUrl', { enabled: site.siteId() === 'default' }],
+        site.siteId() === 'default' && site.path() === '/' ? 'pisaUrl' : null,
         'siteLogoDark',
         'siteLogoLight',
         'siteFavicon',
@@ -57,7 +56,7 @@ provideEditingConfig(Homepage, {
         'sitePortalOverviewPage',
         'siteSearchResultsPage',
         'siteUserProfilePage',
-      ],
+      ].filter((p): p is string => typeof p === 'string'),
       key: 'site-settings-group',
     },
   ],

--- a/src/Objs/Homepage/HomepageEditingConfig.ts
+++ b/src/Objs/Homepage/HomepageEditingConfig.ts
@@ -18,8 +18,7 @@ provideEditingConfig(Homepage, {
     },
     pisaUrl: {
       title: 'PisaSales Portal API URL',
-      description:
-        'Only editable on the default site. Reload the app after changing this value.',
+      description: 'Only editable on the default site.',
     },
     siteLanguageIcon: { title: 'Language icon' },
     siteLogoDark: {

--- a/src/Objs/Homepage/HomepageObjClass.ts
+++ b/src/Objs/Homepage/HomepageObjClass.ts
@@ -7,6 +7,7 @@ export const Homepage = provideObjClass('Homepage', {
     childOrder: 'referencelist',
     contentTitle: 'string',
     metaDataDescription: 'string',
+    pisaUrl: 'string',
     siteCartPage: 'reference',
     siteFavicon: ['reference', { only: 'Image' }],
     siteFooter: ['widgetlist', { only: 'SectionWidget' }],

--- a/src/utils/pisaDataBinaryToUrl.ts
+++ b/src/utils/pisaDataBinaryToUrl.ts
@@ -11,7 +11,7 @@ export async function pisaDataBinaryToUrl(
   }
 
   return {
-    url: pisaUrl() + accessTokens.accessToken,
+    url: (await pisaUrl()) + accessTokens.accessToken,
     maxAge: accessTokens.maxAge,
   }
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -14,8 +14,7 @@ export default defineConfig(({ mode }) => {
   const env = loadEnv(mode, process.cwd(), '')
   const outDir = 'dist'
 
-  const PISA_URL = env.PISA_URL
-  const enablePisa = !!PISA_URL
+  const enablePisa = env.ENABLE_PISA === 'true'
 
   return {
     build: {
@@ -32,7 +31,6 @@ export default defineConfig(({ mode }) => {
     },
     define: {
       'import.meta.env.SCRIVITO_TENANT': JSON.stringify(env.SCRIVITO_TENANT),
-      'import.meta.env.PISA_URL': JSON.stringify(PISA_URL),
       'import.meta.env.ENABLE_PISA': JSON.stringify(enablePisa),
     },
     optimizeDeps: {


### PR DESCRIPTION
Instead of hardcoding the pisa endpoint, the endpoint is now read out from the content of the default homepage. This allows to run multiple instance much easier, since no app adjustments are needed anymore.

The "pisaUrl" content has already been set on the "golden master" tenant.

Still open todos:
* [x] Set `ENABLE_PISA` accordingly on Cloudflare
* [x] Think of, how to avoid the `pisaUrl` in the content dump. First idea: Adjust `dumpContent.ts` to filter out specific `pisaUrl` attribute. => https://github.com/Scrivito/scrivito-portal-app/pull/453