### PR TITLE
Social cards no longer rely on unofficial SDK font

### DIFF
--- a/src/Components/ScrivitoExtensions/SocialCardsTab.scss
+++ b/src/Components/ScrivitoExtensions/SocialCardsTab.scss
@@ -39,30 +39,30 @@ $blueDarken: #0085ac;
 .scrivito_detail_label {
   &.scrivito_error {
     span,
-    .scrivito_icon,
-    .scrivito_icon:hover {
+    .social_card_icon,
+    .social_card_icon:hover {
       color: $red !important;
-      &.scrivito_icon_error:after {
+      &.social_card_icon_error:after {
         filter: drop-shadow(0 2em $red);
       }
     }
   }
   &.scrivito_warning {
     span,
-    .scrivito_icon,
-    .scrivito_icon:hover {
+    .social_card_icon,
+    .social_card_icon:hover {
       color: $yellowDarken !important;
-      &.scrivito_icon_error:after {
+      &.social_card_icon_error:after {
         filter: drop-shadow(0 2em $yellowDarken);
       }
     }
   }
   &.scrivito_info {
     span,
-    .scrivito_icon,
-    .scrivito_icon:hover {
+    .social_card_icon,
+    .social_card_icon:hover {
       color: $blue !important;
-      &.scrivito_icon_error:after {
+      &.social_card_icon_error:after {
         filter: drop-shadow(0 2em $blue);
       }
     }
@@ -117,7 +117,7 @@ $blueDarken: #0085ac;
   color: #eee !important;
 }
 
-.scrivito_icon_error {
+.social_card_icon_error {
   float: left;
   padding: 6px 3px;
   display: table-cell;

--- a/src/Components/ScrivitoExtensions/SocialCardsTab.scss
+++ b/src/Components/ScrivitoExtensions/SocialCardsTab.scss
@@ -42,6 +42,9 @@ $blueDarken: #0085ac;
     .scrivito_icon,
     .scrivito_icon:hover {
       color: $red !important;
+      &.scrivito_icon_error:after {
+        filter: drop-shadow(0 2em $red);
+      }
     }
   }
   &.scrivito_warning {
@@ -49,6 +52,9 @@ $blueDarken: #0085ac;
     .scrivito_icon,
     .scrivito_icon:hover {
       color: $yellowDarken !important;
+      &.scrivito_icon_error:after {
+        filter: drop-shadow(0 2em $yellowDarken);
+      }
     }
   }
   &.scrivito_info {
@@ -56,6 +62,9 @@ $blueDarken: #0085ac;
     .scrivito_icon,
     .scrivito_icon:hover {
       color: $blue !important;
+      &.scrivito_icon_error:after {
+        filter: drop-shadow(0 2em $blue);
+      }
     }
   }
 }
@@ -114,8 +123,14 @@ $blueDarken: #0085ac;
   display: table-cell;
 
   &:after {
-    content: '\F021';
+    content: '\00a0';
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 169.33333 151.87083'%3E%3Cpath d='M92.9 125.1q3.4-3.4 3.4-8.2 0-5-3.4-8.4-3.5-3.5-8.2-3.5-4.8 0-8.2 3.5-3.5 3.4-3.5 8.4 0 4.8 3.5 8.2 3.4 3.5 8.2 3.5 4.7 0 8.2-3.5zM0 131.8q0-6.1 2.6-10.6L67 10q3-4.5 7.4-7.5Q78.8 0 85 0q3.5 0 5 .5 8.5 2.7 12.5 9.6l64.3 111q2.6 4.6 2.6 10.4 0 8.2-5.8 14.5-6.3 5.9-14.5 5.9H20.4q-5.8 0-10.3-2.7-7-4-9.6-12.4-.5-1.6-.5-5Zm78.4-35q2.6 2.7 6.3 2.7 3.7 0 6.2-2.7 2.5-2.6 2.5-6.3v-35q0-3.6-2.5-6.3-2.5-2.6-6.2-2.6t-6.3 2.6Q76 52 76 55.6v34.9q0 3.7 2.5 6.3z'/%3E%3C/svg%3E");
+    background-repeat: no-repeat;
+    clip-path: polygon(0 2em, 1em 2em, 1em 3em, 0 3em);
+    display: block;
     font-size: 13px;
+    margin-top: -1.55em;
+    width: 12px;
   }
 }
 

--- a/src/Components/ScrivitoExtensions/SocialCardsTab.tsx
+++ b/src/Components/ScrivitoExtensions/SocialCardsTab.tsx
@@ -158,7 +158,7 @@ const ContentProperty = connect(
       <>
         <div className={`scrivito_detail_label ${severityClass}`}>
           {severityClass && (
-            <i className="scrivito_icon scrivito_icon_error"></i>
+            <i className="social_card_icon social_card_icon_error"></i>
           )}
           <span>{title}</span>
         </div>


### PR DESCRIPTION
This is something that caught my attention building #461.
The social cards relied on undocumented CSS classes from the Scrivito namespace.
I think there are potentially more clashes with the Scrivito namespace but the font use was most obvious.