### PR TITLE
Localize navigation via app

### DIFF
--- a/src/Widgets/NavigationWidget/NavigationWidgetClass.ts
+++ b/src/Widgets/NavigationWidget/NavigationWidgetClass.ts
@@ -6,7 +6,6 @@ export const NavigationWidget = provideWidgetClass('NavigationWidget', {
     metaNavigationUserDescription: 'string',
     metaNavigationUserTitle: 'string',
     logOutLabel: 'string',
-    searchInputLabel: 'string',
   },
 })
 

--- a/src/Widgets/NavigationWidget/NavigationWidgetClass.ts
+++ b/src/Widgets/NavigationWidget/NavigationWidgetClass.ts
@@ -5,7 +5,6 @@ export const NavigationWidget = provideWidgetClass('NavigationWidget', {
     metaNavigationObjs: 'referencelist',
     metaNavigationUserDescription: 'string',
     metaNavigationUserTitle: 'string',
-    logOutLabel: 'string',
   },
 })
 

--- a/src/Widgets/NavigationWidget/NavigationWidgetComponent.tsx
+++ b/src/Widgets/NavigationWidget/NavigationWidgetComponent.tsx
@@ -23,8 +23,6 @@ provideComponent(NavigationWidget, ({ widget }) => {
     )
   }
 
-  const searchInputLabel = widget.get('searchInputLabel')
-
   return (
     <section>
       <div className="container">
@@ -33,7 +31,7 @@ provideComponent(NavigationWidget, ({ widget }) => {
           <Navbar.Toggle aria-controls="basic-navbar-nav" />
           <Navbar.Collapse id="basic-navbar-nav">
             <MetaNavigation widget={widget} root={root} />
-            <MainNavigation root={root} searchInputLabel={searchInputLabel} />
+            <MainNavigation root={root} />
           </Navbar.Collapse>
         </Navbar>
       </div>

--- a/src/Widgets/NavigationWidget/NavigationWidgetEditingConfig.ts
+++ b/src/Widgets/NavigationWidget/NavigationWidgetEditingConfig.ts
@@ -3,9 +3,7 @@ import { NavigationWidget } from './NavigationWidgetClass'
 import Thumbnail from './thumbnail.svg'
 
 provideEditingConfig(NavigationWidget, {
-  attributes: { logOutLabel: { title: 'Log-out menu item label' } },
   title: 'Navigation',
   thumbnail: Thumbnail,
-  properties: ['metaNavigationObjs', 'logOutLabel'],
-  initialContent: { logOutLabel: 'Log out' },
+  properties: ['metaNavigationObjs'],
 })

--- a/src/Widgets/NavigationWidget/NavigationWidgetEditingConfig.ts
+++ b/src/Widgets/NavigationWidget/NavigationWidgetEditingConfig.ts
@@ -6,6 +6,6 @@ provideEditingConfig(NavigationWidget, {
   attributes: { logOutLabel: { title: 'Log-out menu item label' } },
   title: 'Navigation',
   thumbnail: Thumbnail,
-  properties: ['metaNavigationObjs', 'searchInputLabel', 'logOutLabel'],
-  initialContent: { logOutLabel: 'Log out', searchInputLabel: 'Search' },
+  properties: ['metaNavigationObjs', 'logOutLabel'],
+  initialContent: { logOutLabel: 'Log out' },
 })

--- a/src/Widgets/NavigationWidget/SubComponents/CurrentUserDropdown.tsx
+++ b/src/Widgets/NavigationWidget/SubComponents/CurrentUserDropdown.tsx
@@ -1,6 +1,7 @@
 import {
   connect,
   ContentTag,
+  currentLanguage,
   isCurrentPage,
   isEditorLoggedIn,
   isUserLoggedIn,
@@ -70,16 +71,14 @@ export const CurrentUserDropdown = connect(function CurrentUserDropdown({
         </>
       ) : null}
 
-      <LogOutButton logOutLabel={widget.get('logOutLabel')} root={root} />
+      <LogOutButton root={root} />
     </NavDropdown>
   )
 })
 
 const LogOutButton = connect(function LogOutButton({
-  logOutLabel,
   root,
 }: {
-  logOutLabel: string
   root: HomepageInstance
 }) {
   // TODO: Remove workaround, once #10276 is available
@@ -102,7 +101,7 @@ const LogOutButton = connect(function LogOutButton({
             style={{ color: 'rgba(0, 0, 0, 0.5)' }}
           >
             <i className="bi bi-box-arrow-right"></i>
-            {logOutLabel}
+            {localizeLogOutLabel()}
           </NavDropdown.Item>
         </div>
       </OverlayTrigger>
@@ -118,7 +117,7 @@ const LogOutButton = connect(function LogOutButton({
       onClick={() => logout(rootUrl)}
     >
       <i className="bi bi-box-arrow-right"></i>
-      {logOutLabel}
+      {localizeLogOutLabel()}
     </NavDropdown.Item>
   )
 })
@@ -135,3 +134,12 @@ const ProfileImg = connect(
   },
   { loading: Loading },
 )
+
+function localizeLogOutLabel(): string {
+  switch (currentLanguage()) {
+    case 'de':
+      return 'Abmelden'
+    default:
+      return 'Log out'
+  }
+}

--- a/src/Widgets/NavigationWidget/SubComponents/MainNavigation.tsx
+++ b/src/Widgets/NavigationWidget/SubComponents/MainNavigation.tsx
@@ -6,10 +6,8 @@ import { HomepageInstance } from '../../../Objs/Homepage/HomepageObjClass'
 
 export const MainNavigation = connect(function MainNavigation({
   root,
-  searchInputLabel,
 }: {
   root: HomepageInstance
-  searchInputLabel: string
 }) {
   return (
     <Nav className="navbar-main">
@@ -25,10 +23,7 @@ export const MainNavigation = connect(function MainNavigation({
           />
         )}
       />
-      <SearchBox
-        searchInputLabel={searchInputLabel}
-        searchResultsPage={root.get('siteSearchResultsPage')}
-      />
+      <SearchBox searchResultsPage={root.get('siteSearchResultsPage')} />
     </Nav>
   )
 })

--- a/src/Widgets/NavigationWidget/SubComponents/SearchBox.tsx
+++ b/src/Widgets/NavigationWidget/SubComponents/SearchBox.tsx
@@ -1,11 +1,9 @@
-import { connect, navigateTo, Obj } from 'scrivito'
+import { connect, currentLanguage, navigateTo, Obj } from 'scrivito'
 import { useRef } from 'react'
 
 export const SearchBox = connect(function SearchBox({
-  searchInputLabel,
   searchResultsPage,
 }: {
-  searchInputLabel: string
   searchResultsPage: Obj | null
 }) {
   const inputRef = useRef<HTMLInputElement>(null)
@@ -29,8 +27,8 @@ export const SearchBox = connect(function SearchBox({
         <input
           className="form-control"
           type="search"
-          placeholder={searchInputLabel}
-          aria-label={searchInputLabel}
+          placeholder={localizeSearchInputLabel()}
+          aria-label={localizeSearchInputLabel()}
           ref={inputRef}
         />
 
@@ -41,3 +39,12 @@ export const SearchBox = connect(function SearchBox({
     </form>
   )
 })
+
+function localizeSearchInputLabel(): string {
+  switch (currentLanguage()) {
+    case 'de':
+      return 'Suche'
+    default:
+      return 'Search'
+  }
+}


### PR DESCRIPTION
If I'm not mistaken this was the only remaining place, where we did "label translation" content based. It was a bit in the way (see https://github.com/Scrivito/scrivito-portal-app/pull/478#discussion_r1660754517), so I switched it to "always translate using the app".

Needs content: https://edit.scrivito.com/d0a154d76edf2a7bd991fc658e700a1d~https://localize-navigation-via-app.scrivito-portal-app.pages.dev/de?_scrivito_workspace_id=q3e3e8b37d9c5a75&_scrivito_display_mode=diff