### PR TITLE
Fix a bug when adding columns

### DIFF
--- a/src/Widgets/ColumnContainerWidget/ColumnsEditorTab.tsx
+++ b/src/Widgets/ColumnContainerWidget/ColumnsEditorTab.tsx
@@ -544,7 +544,7 @@ function distributeContents(columns: Widget[], originalContents: Widget[][]) {
     column.update({
       content:
         index < columns.length - 1
-          ? originalContents[index]
+          ? originalContents[index] || []
           : originalContents.slice(index).flat(),
     }),
   )


### PR DESCRIPTION
Adding columns, either by choosing a larger preset or by using the "+" button, lead to `content` being `undefined` under certain conditions. The SDK requires a `Widget[]` and throws an error:

```
ArgumentError: Unexpected value undefined for attribute "content". Expected: An array of Widget instances.
```