### PR TITLE
Normalize padding

### DIFF
--- a/design/author-detail.html
+++ b/design/author-detail.html
@@ -434,7 +434,7 @@
       <!-- Section INFO -->
 
       <!-- Section -->
-      <section class="py-3">
+      <section class="py-2">
         <div class="container">
 
           <h3>More great blog posts from Jane Doe</h3>

--- a/design/author-detail.html
+++ b/design/author-detail.html
@@ -372,7 +372,7 @@
 
     <main id="main">
       <!-- Section -->
-      <section class="bg-light-grey py-4">
+      <section class="bg-light-grey py-5">
         <img
           src="images/AdobeStock_533137076.jpeg"
           class="img-background"

--- a/design/error.html
+++ b/design/error.html
@@ -26,7 +26,7 @@
 
     <main id="main">
       <!-- Section -->
-      <section class="bg-danger vh-100 py-4">
+      <section class="bg-danger vh-100 py-5">
         <img
           src="images/factory-3.jpeg"
           alt="factory"

--- a/design/event-detail.html
+++ b/design/event-detail.html
@@ -242,7 +242,7 @@
 
   <main id="main">
     <!-- Section -->
-    <section class="bg-primary py-4">
+    <section class="bg-primary py-5">
       <img src="images/AdobeStock_220909274.jpeg" class="img-background" alt="..." />
       <div class="container">
         <div class="header-caption">
@@ -337,7 +337,7 @@
 
             <!-- Card Start -->
             <div class="card bg-secondary">
-              <div class="card-body py-4">
+              <div class="card-body py-5">
                 <h3>Event Timetable</h3>
 
                 <table class="table m-0">

--- a/design/event-detail.html
+++ b/design/event-detail.html
@@ -314,7 +314,7 @@
     </section>
     <!-- Section INFO -->
     <!-- Section -->
-    <section class="py-3">
+    <section class="py-2">
       <div class="container">
         <div class="row">
           <div class="col-md-12">
@@ -434,7 +434,7 @@
     <!-- Section -->
 
     <!-- Section -->
-    <section class="py-3">
+    <section class="py-2">
       <div class="container">
         <div class="row">
           <div class="col-md-12">
@@ -487,7 +487,7 @@
     <!-- Section -->
 
     <!-- Section -->
-    <section class="bg-light-grey py-3">
+    <section class="bg-light-grey py-2">
       <div class="container">
         <div class="row">
           <div class="col-md-8 m-auto">

--- a/design/events.html
+++ b/design/events.html
@@ -223,7 +223,7 @@
   <main id="main">
 
     <!-- Section -->
-    <section class="bg-primary py-4">
+    <section class="bg-primary py-5">
       <img class="img-background" src="images/Own image from JR - DXD22_by_www.introduce.berlin_dominik-tryba_INT_4895.jpeg">
       <div class="container ">
         <div class="header-caption">

--- a/design/my-tynacoon-slim-nav.html
+++ b/design/my-tynacoon-slim-nav.html
@@ -117,7 +117,7 @@
 
   <main id="main">
     <!-- Section -->
-    <section class="bg-secondary py-4">
+    <section class="bg-secondary py-5">
       <img src="images/AdobeStock_261052012.jpeg" class="img-background" alt="..." />
       <div class="container">
         <div class="header-caption">

--- a/design/my-tynacoon.html
+++ b/design/my-tynacoon.html
@@ -328,7 +328,7 @@
 
     <main id="main">
       <!-- Section -->
-      <section class="bg-secondary py-4">
+      <section class="bg-secondary py-5">
         <img
           src="images/AdobeStock_261052012.jpeg"
           class="img-background"
@@ -345,7 +345,7 @@
       <!-- Section -->
 
       <!-- Section -->
-      <section class="py-4">
+      <section class="py-5">
         <div class="container">
           <div class="row">
             <div class="col-lg-2">

--- a/design/newsroom-detail.html
+++ b/design/newsroom-detail.html
@@ -374,7 +374,7 @@
 
     <main id="main">
       <!-- Section -->
-      <section class="bg-light-grey py-4">
+      <section class="bg-light-grey py-5">
         <img
           src="images/AdobeStock_533137076.jpeg"
           class="img-background"

--- a/design/newsroom-detail.html
+++ b/design/newsroom-detail.html
@@ -428,7 +428,7 @@
       <!-- Section INFO -->
 
       <!-- Section -->
-      <section class="py-3">
+      <section class="py-2">
         <div class="container">
           <div class="row">
             <div class="col-md-8 m-auto">
@@ -533,7 +533,7 @@
       <!-- Section -->
 
       <!-- Section -->
-      <section class="py-3">
+      <section class="py-2">
         <div class="container">
           <div class="row">
             <div class="col-md-8 m-auto">
@@ -586,7 +586,7 @@
       <!-- Section -->
 
       <!-- Section -->
-      <section class="bg-light-grey py-3">
+      <section class="bg-light-grey py-2">
         <div class="container">
           <div class="row">
             <div class="col-md-8 m-auto">

--- a/design/newsroom.html
+++ b/design/newsroom.html
@@ -223,7 +223,7 @@
   <main id="main">
 
     <!-- Section -->
-    <section class="bg-primary py-4">
+    <section class="bg-primary py-5">
       <video class="img-background" autoplay loop muted>
         <source src="images/pexels-asad-photo-maldives-1675442-1920x1080-60fps.mp4" type="video/mp4" />
       </video>

--- a/design/order-detail.html
+++ b/design/order-detail.html
@@ -374,7 +374,7 @@
 
     <main id="main">
       <!-- Section -->
-      <section class="bg-secondary py-4">
+      <section class="bg-secondary py-5">
         <img
           src="images/AdobeStock_292341430.jpeg"
           class="img-background"
@@ -407,7 +407,7 @@
       <!-- Section Breadcrumb -->
 
       <!-- Section -->
-      <section class="py-4">
+      <section class="py-5">
         <div class="container">
           <div class="row">
             <div class="col-lg-3">

--- a/design/order-overview.html
+++ b/design/order-overview.html
@@ -377,7 +377,7 @@
 
     <main id="main">
       <!-- Section -->
-      <section class="bg-secondary py-4">
+      <section class="bg-secondary py-5">
         <img
           src="images/AdobeStock_292341430.jpeg"
           class="img-background"
@@ -409,7 +409,7 @@
       <!-- Section Breadcrumb -->
 
       <!-- Section -->
-      <section class="py-4">
+      <section class="py-5">
         <div class="container">
           <div class="row">
             <div class="col-lg-3">

--- a/design/product-detail.html
+++ b/design/product-detail.html
@@ -396,7 +396,7 @@
       <!-- Section Breadcrumb -->
 
       <!-- Section -->
-      <section class="py-4">
+      <section class="py-5">
         <div class="container">
           <div class="row align-items-stretch">
             <div class="col-md-4">
@@ -553,7 +553,7 @@
       <!-- Section -->
 
       <!-- Section -->
-      <section class="bg-light-grey py-4">
+      <section class="bg-light-grey py-5">
         <div class="container">
           <h3 class="h4" id="description">Description</h3>
 
@@ -576,7 +576,7 @@
       <!-- Section -->
 
       <!-- Section -->
-      <section class="py-4">
+      <section class="py-5">
         <div class="container">
           <h3 class="h4" id="data">Data</h3>
 
@@ -624,7 +624,7 @@
       <!-- Section -->
 
       <!-- Section -->
-      <section class="bg-light-grey py-4">
+      <section class="bg-light-grey py-5">
         <div class="container">
           <h3 class="h4" id="downloads">Downloads</h3>
 
@@ -796,7 +796,7 @@
       <!-- Section -->
 
       <!-- Section -->
-      <section class="py-4">
+      <section class="py-5">
         <div class="container">
           <h3 class="h4" id="accessories">Suitable accessories</h3>
 
@@ -1015,7 +1015,7 @@
       <!-- Section -->
 
       <!-- Section -->
-      <section class="bg-primary py-4">
+      <section class="bg-primary py-5">
         <div class="container">
           <h3 class="h4" id="description">More</h3>
         </div>

--- a/design/products-filter-detail.html
+++ b/design/products-filter-detail.html
@@ -374,7 +374,7 @@
 
     <main id="main">
       <!-- Section -->
-      <section class="bg-primary py-4">
+      <section class="bg-primary py-5">
         <img
           src="images/AdobeStock_533137076.jpeg"
           class="img-background"
@@ -410,7 +410,7 @@
       <!-- Section Breadcrumb -->
 
       <!-- Section -->
-      <section class="py-4">
+      <section class="py-5">
         <div class="container">
           <div class="row">
             <div class="col-lg-3">

--- a/design/products-filter.html
+++ b/design/products-filter.html
@@ -374,7 +374,7 @@
 
     <main id="main">
       <!-- Section -->
-      <section class="bg-primary py-4">
+      <section class="bg-primary py-5">
         <img
           src="images/AdobeStock_533137076.jpeg"
           class="img-background"
@@ -410,7 +410,7 @@
       <!-- Section Breadcrumb -->
 
       <!-- Section -->
-      <section class="py-4">
+      <section class="py-5">
         <div class="container">
           <div class="row">
             <div class="col-lg-3">

--- a/design/products-overview.html
+++ b/design/products-overview.html
@@ -216,7 +216,7 @@
     <main id="main">
 
       <!-- Section -->
-      <section class="bg-primary py-4">
+      <section class="bg-primary py-5">
         <img src="images/AdobeStock_533137076.jpeg" class="img-background" alt="...">
         <div class="container ">
           <div class="header-caption">

--- a/design/profile.html
+++ b/design/profile.html
@@ -328,7 +328,7 @@
 
     <main id="main">
       <!-- Section -->
-      <section class="bg-secondary py-4">
+      <section class="bg-secondary py-5">
         <img
           src="images/AdobeStock_398495387.jpeg"
           class="img-background"
@@ -345,7 +345,7 @@
       <!-- Section -->
 
       <!-- Section -->
-      <section class="py-4">
+      <section class="py-5">
         <div class="container">
           <div class="row">
             <div class="col-lg-2">

--- a/design/sales-detail.html
+++ b/design/sales-detail.html
@@ -443,7 +443,7 @@
       <!-- Section INFO -->
 
       <!-- Section -->
-      <section class="py-3">
+      <section class="py-2">
         <div class="container">
 
           <h3>More relevant topics about Jane Doe</h3>

--- a/design/sales-detail.html
+++ b/design/sales-detail.html
@@ -372,7 +372,7 @@
 
     <main id="main">
       <!-- Section -->
-      <section class="bg-light-grey py-4">
+      <section class="bg-light-grey py-5">
         <img
           src="images/AdobeStock_533137076.jpeg"
           class="img-background"

--- a/design/search.html
+++ b/design/search.html
@@ -428,7 +428,7 @@
       <!-- Section-->
 
       <!-- Section -->
-      <section class="bg-white py-3">
+      <section class="bg-white py-2">
         <div class="container">
           <div class="card bg-light-grey my-4">
             <div class="row g-0">

--- a/design/search.html
+++ b/design/search.html
@@ -374,7 +374,7 @@
 
     <main id="main">
       <!-- Section -->
-      <section class="bg-primary py-4">
+      <section class="bg-primary py-5">
         <img
           src="images/AdobeStock_99144921.jpeg"
           alt="factory"

--- a/design/ticket-detail.html
+++ b/design/ticket-detail.html
@@ -242,7 +242,7 @@
 
   <main id="main">
     <!-- Section -->
-    <section class="bg-secondary py-4">
+    <section class="bg-secondary py-5">
       <img src="images/AdobeStock_292341430.jpeg" class="img-background" alt="..." />
       <div class="container">
         <div class="header-caption">
@@ -271,7 +271,7 @@
     <!-- Section Breadcrumb -->
 
     <!-- Section -->
-    <section class="bg-light-grey py-4">
+    <section class="bg-light-grey py-5">
       <div class="container">
         <div class="row">
           <div class="col-lg-2">

--- a/src/Components/ErrorBoundary.tsx
+++ b/src/Components/ErrorBoundary.tsx
@@ -28,7 +28,7 @@ export class ErrorBoundary extends React.Component<
     if (!this.state.hasError) return this.props.children
 
     return (
-      <section className="bg-danger vh-100 py-4">
+      <section className="bg-danger vh-100 py-5">
         <img
           src={errorBackground}
           alt="factory"

--- a/src/Objs/Product/ProductComponent.tsx
+++ b/src/Objs/Product/ProductComponent.tsx
@@ -24,7 +24,7 @@ provideComponent(Product, ({ page }) => {
 
   return (
     <main id="main">
-      <section className="bg-light-grey py-4">
+      <section className="bg-light-grey py-5">
         <div className="container">
           <div className="row align-items-stretch">
             <div className="col-md-4 mb-4">
@@ -119,7 +119,7 @@ provideComponent(Product, ({ page }) => {
           <ContentTag content={page} attribute="descriptionSection" />
         </div>
       </section>
-      <section className="py-4">
+      <section className="py-5">
         <div className="container">
           <Label tag="h3" className="h4" id="data" localizer="data" />
           <div className="row">
@@ -143,13 +143,13 @@ provideComponent(Product, ({ page }) => {
           </div>
         </div>
       </section>
-      <section className="bg-light-grey py-4">
+      <section className="bg-light-grey py-5">
         <div className="container">
           <Label tag="h3" className="h4" id="downloads" localizer="downloads" />
           <ContentTag content={page} attribute="downloadsSection" />
         </div>
       </section>
-      <section className="bg-primary py-4">
+      <section className="bg-primary py-5">
         <div className="container">
           <Label
             tag="h3"

--- a/src/Objs/ProductCategory/ProductCategoryComponent.tsx
+++ b/src/Objs/ProductCategory/ProductCategoryComponent.tsx
@@ -11,7 +11,7 @@ provideComponent(ProductCategory, ({ page }) => {
 
   return (
     <main id="main">
-      <section className="bg-light-grey py-4">
+      <section className="bg-light-grey py-5">
         <div className="container">
           <div className="row">
             <div className="col-lg-12">

--- a/src/Objs/ProductsOverview/ProductOverviewLayoutComponent.tsx
+++ b/src/Objs/ProductsOverview/ProductOverviewLayoutComponent.tsx
@@ -11,7 +11,7 @@ import { Breadcrumb } from '../../Components/Breadcrumb'
 
 provideLayoutComponent(ProductsOverview, ({ page }) => (
   <>
-    <section className="bg-primary py-4">
+    <section className="bg-primary py-5">
       <InPlaceEditingOff>
         <ImageTag
           content={page}

--- a/src/Widgets/SearchResultsWidget/SearchResultsWidgetComponent.tsx
+++ b/src/Widgets/SearchResultsWidget/SearchResultsWidgetComponent.tsx
@@ -39,7 +39,7 @@ provideComponent(SearchResultsWidget, ({ widget }) => {
 
   return (
     <InPlaceEditingOff>
-      <section className="bg-primary py-4">
+      <section className="bg-primary py-5">
         <ImageTag
           content={widget}
           attribute="topBannerBackground"

--- a/src/Widgets/SearchResultsWidget/SearchResultsWidgetComponent.tsx
+++ b/src/Widgets/SearchResultsWidget/SearchResultsWidgetComponent.tsx
@@ -80,7 +80,7 @@ provideComponent(SearchResultsWidget, ({ widget }) => {
         </div>
       </section>
 
-      <section className="bg-white py-3">
+      <section className="bg-white py-2">
         <SearchResults
           search={search}
           query={query}

--- a/src/Widgets/SectionWidget/SectionWidgetComponent.tsx
+++ b/src/Widgets/SectionWidget/SectionWidgetComponent.tsx
@@ -15,7 +15,7 @@ provideComponent(SectionWidget, ({ widget }) => {
     sectionClassNames.push(`bg-${backgroundColor}`)
   }
 
-  if (widget.get('showPadding')) sectionClassNames.push('py-5')
+  sectionClassNames.push(widget.get('showPadding') ? 'py-5' : 'py-2')
 
   let contentClassName = 'container'
   if (widget.get('containerWidth') === '95-percent') {


### PR DESCRIPTION
# Overall goal
There are only two types of sections: One with padding (`py-5`) and one "without" padding (`py-2`). This allows me to use the SectionWidget as is (after this PR) for layout components like current page title or breadcrumbs.

AFAIK we currently have no `SectionWidget` with `showPadding` set to `false` in our Scrivito content.