### PR TITLE
BreadcrumbWidget

### DIFF
--- a/src/Widgets/BreadcrumbWidget/BreadcrumbWidgetClass.ts
+++ b/src/Widgets/BreadcrumbWidget/BreadcrumbWidgetClass.ts
@@ -1,0 +1,3 @@
+import { provideWidgetClass } from 'scrivito'
+
+export const BreadcrumbWidget = provideWidgetClass('BreadcrumbWidget', {})

--- a/src/Widgets/BreadcrumbWidget/BreadcrumbWidgetComponent.tsx
+++ b/src/Widgets/BreadcrumbWidget/BreadcrumbWidgetComponent.tsx
@@ -1,0 +1,25 @@
+import { LinkTag, Obj, currentPage, provideComponent } from 'scrivito'
+import { BreadcrumbWidget } from './BreadcrumbWidgetClass'
+import { objTitle } from '../../utils/objTitle'
+
+provideComponent(BreadcrumbWidget, () => {
+  const currentPageObj = currentPage()
+  if (!currentPageObj) return <nav aria-label="breadcrumb" />
+
+  const breadcrumbItems = currentPageObj
+    .ancestors()
+    .filter((item): item is Obj => !!item && !item.get('hideInNavigation'))
+
+  return (
+    <nav aria-label="breadcrumb">
+      <ol className="breadcrumb m-1">
+        {breadcrumbItems.map((obj) => (
+          <li className="breadcrumb-item" key={obj.id()}>
+            <LinkTag to={obj}>{objTitle(obj)}</LinkTag>
+          </li>
+        ))}
+        <li className="breadcrumb-item active">{objTitle(currentPageObj)}</li>
+      </ol>
+    </nav>
+  )
+})

--- a/src/Widgets/BreadcrumbWidget/BreadcrumbWidgetEditingConfig.ts
+++ b/src/Widgets/BreadcrumbWidget/BreadcrumbWidgetEditingConfig.ts
@@ -1,0 +1,6 @@
+import { provideEditingConfig } from 'scrivito'
+import { BreadcrumbWidget } from './BreadcrumbWidgetClass'
+
+provideEditingConfig(BreadcrumbWidget, {
+  title: 'Breadcrumb',
+})


### PR DESCRIPTION
To be later used in layoutHeader to replace hardcoded `<Breadcrumb />` in SubnavigationOverviewLayout and ProductOverviewLayout.

Thumbnail will be added later.