### PR TITLE
Full-screen submit indicator

### DIFF
--- a/src/Components/ModalSpinner.tsx
+++ b/src/Components/ModalSpinner.tsx
@@ -2,7 +2,7 @@ import { useEffect, useRef } from 'react'
 import { Modal } from 'react-bootstrap'
 import { connect } from 'scrivito'
 
-export const Submitting = connect(function Submitting() {
+export const ModalSpinner = connect(function ModalSpinner() {
   const dialogRef = useRef<HTMLDialogElement>(null)
   useEffect(() => dialogRef.current?.showModal(), [])
 

--- a/src/Components/Submitting.tsx
+++ b/src/Components/Submitting.tsx
@@ -1,14 +1,22 @@
+import { useEffect, useRef } from 'react'
 import { Modal } from 'react-bootstrap'
 import { connect } from 'scrivito'
 
 export const Submitting = connect(function Submitting() {
+  const dialogRef = useRef<HTMLDialogElement>(null)
+  useEffect(() => dialogRef.current?.showModal(), [])
+
   return (
-    <Modal
-      backdrop="static"
-      centered
-      dialogAs={() => <div className="loader" />}
-      fullscreen
-      show
-    />
+    <>
+      <dialog className="d-none" ref={dialogRef} />
+      <Modal
+        backdrop="static"
+        centered
+        dialogAs={() => <div className="loader" />}
+        fullscreen
+        keyboard={false}
+        show
+      />
+    </>
   )
 })

--- a/src/Components/Submitting.tsx
+++ b/src/Components/Submitting.tsx
@@ -1,0 +1,14 @@
+import { Modal } from 'react-bootstrap'
+import { connect } from 'scrivito'
+
+export const Submitting = connect(function Submitting() {
+  return (
+    <Modal
+      backdrop="static"
+      centered
+      dialogAs={() => <div className="loader" />}
+      fullscreen
+      show
+    />
+  )
+})

--- a/src/Widgets/CheckoutButtonWidget/CheckoutButtonWidgetComponent.tsx
+++ b/src/Widgets/CheckoutButtonWidget/CheckoutButtonWidgetComponent.tsx
@@ -13,6 +13,7 @@ import { alignmentClassNameWithBlock } from '../../utils/alignmentClassName'
 import { EditorNote } from '../../Components/EditorNote'
 import { buttonSizeClassName } from '../../utils/buttonSizeClassName'
 import { useState } from 'react'
+import { Submitting } from '../../Components/Submitting'
 
 provideComponent(CheckoutButtonWidget, ({ widget }) => {
   const [isSubmitting, setIsSubmitting] = useState(false)
@@ -42,7 +43,7 @@ provideComponent(CheckoutButtonWidget, ({ widget }) => {
           onClick={onClick}
         />
       </InPlaceEditingOff>
-      {isSubmitting && <div className="loader" />}
+      {isSubmitting && <Submitting />}
     </WidgetTag>
   )
 

--- a/src/Widgets/CheckoutButtonWidget/CheckoutButtonWidgetComponent.tsx
+++ b/src/Widgets/CheckoutButtonWidget/CheckoutButtonWidgetComponent.tsx
@@ -13,7 +13,7 @@ import { alignmentClassNameWithBlock } from '../../utils/alignmentClassName'
 import { EditorNote } from '../../Components/EditorNote'
 import { buttonSizeClassName } from '../../utils/buttonSizeClassName'
 import { useState } from 'react'
-import { Submitting } from '../../Components/Submitting'
+import { ModalSpinner } from '../../Components/ModalSpinner'
 
 provideComponent(CheckoutButtonWidget, ({ widget }) => {
   const [isSubmitting, setIsSubmitting] = useState(false)
@@ -43,7 +43,7 @@ provideComponent(CheckoutButtonWidget, ({ widget }) => {
           onClick={onClick}
         />
       </InPlaceEditingOff>
-      {isSubmitting && <Submitting />}
+      {isSubmitting && <ModalSpinner />}
     </WidgetTag>
   )
 

--- a/src/Widgets/DataFormContainerWidget/DataFormContainerWidgetComponent.tsx
+++ b/src/Widgets/DataFormContainerWidget/DataFormContainerWidgetComponent.tsx
@@ -13,6 +13,7 @@ import { DataFormContainerWidget } from './DataFormContainerWidgetClass'
 import { toast } from 'react-toastify'
 import { useRef, useState } from 'react'
 import './DataFormContainerWidget.scss'
+import { Submitting } from '../../Components/Submitting'
 
 provideComponent(DataFormContainerWidget, ({ widget }) => {
   const dataItem = useDataItem()
@@ -42,7 +43,7 @@ provideComponent(DataFormContainerWidget, ({ widget }) => {
         </InPlaceEditingOff>
 
         <ContentTag content={widget} attribute="content" />
-        {isSubmitting && <div className="loader" />}
+        {isSubmitting && <Submitting />}
       </form>
     </WidgetTag>
   )

--- a/src/Widgets/DataFormContainerWidget/DataFormContainerWidgetComponent.tsx
+++ b/src/Widgets/DataFormContainerWidget/DataFormContainerWidgetComponent.tsx
@@ -13,7 +13,7 @@ import { DataFormContainerWidget } from './DataFormContainerWidgetClass'
 import { toast } from 'react-toastify'
 import { useRef, useState } from 'react'
 import './DataFormContainerWidget.scss'
-import { Submitting } from '../../Components/Submitting'
+import { ModalSpinner } from '../../Components/ModalSpinner'
 
 provideComponent(DataFormContainerWidget, ({ widget }) => {
   const dataItem = useDataItem()
@@ -43,7 +43,7 @@ provideComponent(DataFormContainerWidget, ({ widget }) => {
         </InPlaceEditingOff>
 
         <ContentTag content={widget} attribute="content" />
-        {isSubmitting && <Submitting />}
+        {isSubmitting && <ModalSpinner />}
       </form>
     </WidgetTag>
   )


### PR DESCRIPTION
See https://github.com/Scrivito/scrivito-portal-app/pull/494#discussion_r1668561059

For now, the visuals are a bit more intrusive (dark overlay) compared to what we had before.
Depending on the overlay appearance we choose, we could consider getting rid of styling forms (`form-loading`) and buttons (`disabled`) differently while submitting.

We use a hidden dialog b/c a dialog background apparently can't be made transparent.