### PR TITLE
[OnDevSdk] Adapt to new API for `provideDataClass({ restApi })`

### DIFF
--- a/src/Data/Contract/Pisa/pisaContractDataClass.ts
+++ b/src/Data/Contract/Pisa/pisaContractDataClass.ts
@@ -1,8 +1,11 @@
 import { provideDataClass } from 'scrivito'
-import { pisaClient } from '../../pisaClient'
+import { pisaConfig } from '../../pisaClient'
 
 export async function pisaContractDataClass() {
-  const contractClient = await pisaClient('contract')
+  const contractConfig = await pisaConfig('contract')
 
-  return provideDataClass('Contract', { restApi: contractClient })
+  return provideDataClass('Contract', {
+    restApi: contractConfig,
+    attributes: {},
+  })
 }

--- a/src/Data/ContractDocument/Pisa/pisaContractDocumentDataClass.ts
+++ b/src/Data/ContractDocument/Pisa/pisaContractDocumentDataClass.ts
@@ -1,10 +1,11 @@
 import { provideDataClass } from 'scrivito'
-import { pisaClient } from '../../pisaClient'
+import { pisaConfig } from '../../pisaClient'
 
 export async function pisaContractDocumentDataClass() {
-  const contractDocumentClient = await pisaClient('contract-document')
+  const contractDocumentConfig = await pisaConfig('contract-document')
 
   return provideDataClass('ContractDocument', {
-    restApi: contractDocumentClient,
+    restApi: contractDocumentConfig,
+    attributes: {},
   })
 }

--- a/src/Data/EventDocument/Pisa/pisaEventDocumentDataClass.ts
+++ b/src/Data/EventDocument/Pisa/pisaEventDocumentDataClass.ts
@@ -1,10 +1,11 @@
 import { provideDataClass } from 'scrivito'
-import { pisaClient } from '../../pisaClient'
+import { pisaConfig } from '../../pisaClient'
 
 export async function pisaEventDocumentDataClass() {
-  const eventDocumentClient = await pisaClient('event-document')
+  const eventDocumentConfig = await pisaConfig('event-document')
 
   return provideDataClass('EventDocument', {
-    restApi: eventDocumentClient,
+    restApi: eventDocumentConfig,
+    attributes: {},
   })
 }

--- a/src/Data/EventRegistration/Pisa/pisaEventRegistrationDataClass.ts
+++ b/src/Data/EventRegistration/Pisa/pisaEventRegistrationDataClass.ts
@@ -1,10 +1,11 @@
 import { provideDataClass } from 'scrivito'
-import { pisaClient } from '../../pisaClient'
+import { pisaConfig } from '../../pisaClient'
 
 export async function pisaEventRegistrationDataClass() {
-  const eventRegistrationClient = await pisaClient('event-registration')
+  const eventRegistrationConfig = await pisaConfig('event-registration')
 
   return provideDataClass('EventRegistration', {
-    restApi: eventRegistrationClient,
+    restApi: eventRegistrationConfig,
+    attributes: {},
   })
 }

--- a/src/Data/Gdpr/Pisa/pisaGdprDataClass.ts
+++ b/src/Data/Gdpr/Pisa/pisaGdprDataClass.ts
@@ -1,8 +1,11 @@
 import { provideDataClass } from 'scrivito'
-import { pisaClient } from '../../pisaClient'
+import { pisaConfig } from '../../pisaClient'
 
 export async function pisaGdprDataClass() {
-  const gdprClient = await pisaClient('gdpr')
+  const gdprConfig = await pisaConfig('gdpr')
 
-  return provideDataClass('Gdpr', { restApi: gdprClient })
+  return provideDataClass('Gdpr', {
+    restApi: gdprConfig,
+    attributes: {},
+  })
 }

--- a/src/Data/Opportunity/Pisa/pisaOpportunityDataClass.ts
+++ b/src/Data/Opportunity/Pisa/pisaOpportunityDataClass.ts
@@ -1,10 +1,11 @@
 import { provideDataClass } from 'scrivito'
-import { pisaClient } from '../../pisaClient'
+import { pisaConfig } from '../../pisaClient'
 
 export async function pisaOpportunityDataClass() {
-  const opportunityClient = await pisaClient('opportunity')
+  const opportunityConfig = await pisaConfig('opportunity')
 
   return provideDataClass('Opportunity', {
-    restApi: opportunityClient,
+    restApi: opportunityConfig,
+    attributes: {},
   })
 }

--- a/src/Data/Order/Pisa/pisaOrderDataClass.ts
+++ b/src/Data/Order/Pisa/pisaOrderDataClass.ts
@@ -1,8 +1,11 @@
 import { provideDataClass } from 'scrivito'
-import { pisaClient } from '../../pisaClient'
+import { pisaConfig } from '../../pisaClient'
 
 export async function pisaOrderDataClass() {
-  const orderClient = await pisaClient('order')
+  const orderConfig = await pisaConfig('order')
 
-  return provideDataClass('Order', { restApi: orderClient })
+  return provideDataClass('Order', {
+    restApi: orderConfig,
+    attributes: {},
+  })
 }

--- a/src/Data/OrderDocument/Pisa/pisaOrderDocumentDataClass.ts
+++ b/src/Data/OrderDocument/Pisa/pisaOrderDocumentDataClass.ts
@@ -1,10 +1,11 @@
 import { provideDataClass } from 'scrivito'
-import { pisaClient } from '../../pisaClient'
+import { pisaConfig } from '../../pisaClient'
 
 export async function pisaOrderDocumentDataClass() {
-  const orderDocumentClient = await pisaClient('order-document')
+  const orderDocumentConfig = await pisaConfig('order-document')
 
   return provideDataClass('OrderDocument', {
-    restApi: orderDocumentClient,
+    restApi: orderDocumentConfig,
+    attributes: {},
   })
 }

--- a/src/Data/OrderRequest/Pisa/pisaOrderRequestDataClass.ts
+++ b/src/Data/OrderRequest/Pisa/pisaOrderRequestDataClass.ts
@@ -1,8 +1,11 @@
 import { provideDataClass } from 'scrivito'
-import { pisaClient } from '../../pisaClient'
+import { pisaConfig } from '../../pisaClient'
 
 export async function pisaOrderRequestDataClass() {
-  const orderRequestClient = await pisaClient('order-request')
+  const orderRequestConfig = await pisaConfig('order-request')
 
-  return provideDataClass('OrderRequest', { restApi: orderRequestClient })
+  return provideDataClass('OrderRequest', {
+    restApi: orderRequestConfig,
+    attributes: {},
+  })
 }

--- a/src/Data/Quote/Pisa/pisaQuoteDataClass.ts
+++ b/src/Data/Quote/Pisa/pisaQuoteDataClass.ts
@@ -1,8 +1,8 @@
 import { provideDataClass } from 'scrivito'
-import { pisaClient } from '../../pisaClient'
+import { pisaConfig } from '../../pisaClient'
 
 export async function pisaQuoteDataClass() {
-  const quoteClient = await pisaClient('quote')
+  const quoteConfig = await pisaConfig('quote')
 
-  return provideDataClass('Quote', { restApi: quoteClient })
+  return provideDataClass('Quote', { restApi: quoteConfig, attributes: {} })
 }

--- a/src/Data/QuoteDocument/Pisa/pisaQuoteDocumentDataClass.ts
+++ b/src/Data/QuoteDocument/Pisa/pisaQuoteDocumentDataClass.ts
@@ -1,10 +1,11 @@
 import { provideDataClass } from 'scrivito'
-import { pisaClient } from '../../pisaClient'
+import { pisaConfig } from '../../pisaClient'
 
 export async function pisaQuoteDocumentDataClass() {
-  const quoteDocumentClient = await pisaClient('quote-document')
+  const quoteDocumentConfig = await pisaConfig('quote-document')
 
   return provideDataClass('QuoteDocument', {
-    restApi: quoteDocumentClient,
+    restApi: quoteDocumentConfig,
+    attributes: {},
   })
 }

--- a/src/Data/ServiceObjectDocument/Pisa/pisaServiceObjectDocumentDataClass.ts
+++ b/src/Data/ServiceObjectDocument/Pisa/pisaServiceObjectDocumentDataClass.ts
@@ -1,12 +1,13 @@
 import { provideDataClass } from 'scrivito'
-import { pisaClient } from '../../pisaClient'
+import { pisaConfig } from '../../pisaClient'
 
 export async function pisaServiceObjectDocumentDataClass() {
-  const serviceObjectDocumentClient = await pisaClient(
+  const serviceObjectDocumentConfig = await pisaConfig(
     'service-object-document',
   )
 
   return provideDataClass('ServiceObjectDocument', {
-    restApi: serviceObjectDocumentClient,
+    restApi: serviceObjectDocumentConfig,
+    attributes: {},
   })
 }

--- a/src/Data/pisaClient.ts
+++ b/src/Data/pisaClient.ts
@@ -15,12 +15,18 @@ export async function pisaUrl(): Promise<string> {
 }
 
 export async function pisaClient(subPath: string) {
+  const { url, headers } = await pisaConfig(subPath)
+
+  return createRestApiClient(url, { headers })
+}
+
+export async function pisaConfig(subPath: string) {
   const url = `${await pisaUrl()}/${subPath}`
 
   const language = await load(() => currentLanguage() ?? 'en')
   const headers = { 'Accept-Language': language }
 
-  return createRestApiClient(url, { headers })
+  return { url, headers }
 }
 
 function never() {


### PR DESCRIPTION
See https://github.com/infopark/scrivito_js/pull/11025

https://infopark.slack.com/archives/G01F5J9817Z/p1720631421230469

/cc @patrykboch 