### PR TITLE
Fix ServiceObjectDocument editing config labels

### DIFF
--- a/src/Data/ServiceObjectDocument/ServiceObjectDocumentEditingConfig.ts
+++ b/src/Data/ServiceObjectDocument/ServiceObjectDocumentEditingConfig.ts
@@ -3,9 +3,9 @@ import { ServiceObjectDocumentPromise } from './ServiceObjectDocumentDataClass'
 
 ServiceObjectDocumentPromise.then((ServiceObjectDocument) => {
   provideEditingConfig(ServiceObjectDocument, {
-    title: 'Equipment document',
+    title: 'Service object document',
     attributes: {
-      serviceObjectId: { title: 'Equipment ID' },
+      serviceObjectId: { title: 'Service object ID' },
       documentId: { title: 'Document ID' },
     },
   })


### PR DESCRIPTION
The term "equipment" is used in the visitor presentation layer only. Here, we're at the backend data layer.