### PR TITLE
Extend multi-site config to allow for isolated sites

### DIFF
--- a/src/config/scrivitoSites.ts
+++ b/src/config/scrivitoSites.ts
@@ -34,23 +34,20 @@ export function siteForUrl(
   }
 
   const baseAppUrl = getBaseAppUrl()
-  if (!baseAppUrl) return
-
   const language = languageForUrl(url, baseAppUrl)
-  if (!language) return
+  const languageSite = language
+    ? appWebsites().and('_language', 'equals', language).first()
+    : undefined
+  const languageSiteId = languageSite?.siteId()
 
-  const languageSite = appWebsites()
-    .and('_language', 'equals', language)
-    .first()
-  if (!languageSite) return
-
-  const languageSiteId = languageSite.siteId()
   if (!languageSiteId) return
 
   return { baseUrl: `${baseAppUrl}/${language}`, siteId: languageSiteId }
 }
 
-function languageForUrl(url: string, baseAppUrl: string) {
+function languageForUrl(url: string, baseAppUrl?: string) {
+  if (!baseAppUrl) return
+
   const regex = new RegExp(`^${baseAppUrl}\\/(?<lang>[a-z]{2})([?/]|$)`)
   return regex.exec(url)?.groups?.lang
 }

--- a/src/config/scrivitoSites.ts
+++ b/src/config/scrivitoSites.ts
@@ -36,8 +36,7 @@ export function siteForUrl(
   const baseAppUrl = getBaseAppUrl()
   if (!baseAppUrl) return
 
-  const regex = new RegExp(`^${baseAppUrl}\\/(?<lang>[a-z]{2})([?/]|$)`)
-  const language = regex.exec(url)?.groups?.lang
+  const language = languageForUrl(url, baseAppUrl)
   if (!language) return
 
   const languageSite = appWebsites()
@@ -49,6 +48,11 @@ export function siteForUrl(
   if (!languageSiteId) return
 
   return { baseUrl: `${baseAppUrl}/${language}`, siteId: languageSiteId }
+}
+
+function languageForUrl(url: string, baseAppUrl: string) {
+  const regex = new RegExp(`^${baseAppUrl}\\/(?<lang>[a-z]{2})([?/]|$)`)
+  return regex.exec(url)?.groups?.lang
 }
 
 export async function ensureSiteIsPresent() {

--- a/src/config/scrivitoSites.ts
+++ b/src/config/scrivitoSites.ts
@@ -8,11 +8,12 @@ import {
   urlFor,
 } from 'scrivito'
 import { isMultitenancyEnabled } from './scrivitoTenants'
+import { ensureString } from '../utils/ensureString'
 
 const location = typeof window !== 'undefined' ? window.location : undefined
 
 const rootContentId =
-  import.meta.env.SCRIVITO_ROOT_CONTENT_ID || 'c2a0aab78be05a4e'
+  ensureString(import.meta.env.SCRIVITO_ROOT_CONTENT_ID) || 'c2a0aab78be05a4e'
 
 const NEOLETTER_MAILINGS_SITE_ID = 'mailing-app'
 

--- a/src/config/scrivitoSites.ts
+++ b/src/config/scrivitoSites.ts
@@ -11,7 +11,7 @@ import { isMultitenancyEnabled } from './scrivitoTenants'
 
 const location = typeof window !== 'undefined' ? window.location : undefined
 
-const rootContentId: string =
+const rootContentId =
   import.meta.env.SCRIVITO_ROOT_CONTENT_ID || 'c2a0aab78be05a4e'
 
 const NEOLETTER_MAILINGS_SITE_ID = 'mailing-app'

--- a/src/config/scrivitoSites.ts
+++ b/src/config/scrivitoSites.ts
@@ -10,7 +10,9 @@ import {
 import { isMultitenancyEnabled } from './scrivitoTenants'
 
 const location = typeof window !== 'undefined' ? window.location : undefined
-const rootContentId = import.meta.env.SCRIVITO_ROOT_CONTENT_ID
+
+const rootContentId: string =
+  import.meta.env.SCRIVITO_ROOT_CONTENT_ID || 'c2a0aab78be05a4e'
 
 const NEOLETTER_MAILINGS_SITE_ID = 'mailing-app'
 
@@ -22,7 +24,7 @@ export function baseUrlForSite(siteId: string): string | undefined {
   const siteRoot = Obj.onSite(siteId).root()
   if (!siteRoot) return
 
-  if (rootContentId && siteRoot.contentId() !== rootContentId) {
+  if (siteRoot.contentId() !== rootContentId) {
     return baseUrlsFor(siteRoot)[0]
   }
 
@@ -63,8 +65,6 @@ function languageForUrl(url: string, baseAppUrl?: string) {
 }
 
 function findSiteForUrl(url: string) {
-  if (!rootContentId) return
-
   const sites = allWebsites()
     .toArray()
     .filter((site) =>
@@ -117,9 +117,7 @@ function getBaseAppUrl(): string | undefined {
 }
 
 function appWebsites() {
-  return rootContentId
-    ? Obj.onAllSites().where('_contentId', 'equals', rootContentId)
-    : allWebsites()
+  return Obj.onAllSites().where('_contentId', 'equals', rootContentId)
 }
 
 function allWebsites() {

--- a/src/config/scrivitoSites.ts
+++ b/src/config/scrivitoSites.ts
@@ -46,8 +46,7 @@ export function siteForUrl(
     return { baseUrl: neoletterBaseUrl, siteId: NEOLETTER_MAILINGS_SITE_ID }
   }
 
-  const baseAppUrl = getBaseAppUrl()
-  const language = languageForUrl(url, baseAppUrl)
+  const language = languageForUrl(url)
   const languageSite = language
     ? appWebsites().and('_language', 'equals', language).first()
     : undefined
@@ -55,13 +54,11 @@ export function siteForUrl(
 
   if (!languageSiteId) return findSiteForUrl(url)
 
-  return { baseUrl: `${baseAppUrl}/${language}`, siteId: languageSiteId }
+  return { baseUrl: `${getBaseAppUrl()}/${language}`, siteId: languageSiteId }
 }
 
-function languageForUrl(url: string, baseAppUrl?: string) {
-  if (!baseAppUrl) return
-
-  const regex = new RegExp(`^${baseAppUrl}\\/(?<lang>[a-z]{2})([?/]|$)`)
+function languageForUrl(url: string) {
+  const regex = new RegExp(`^${getBaseAppUrl()}\\/(?<lang>[a-z]{2})([?/]|$)`)
   return regex.exec(url)?.groups?.lang
 }
 

--- a/src/config/scrivitoSites.ts
+++ b/src/config/scrivitoSites.ts
@@ -66,21 +66,16 @@ function languageForUrl(url: string, baseAppUrl?: string) {
 }
 
 function findSiteForUrl(url: string) {
-  const sites = allWebsites()
+  return Obj.onAllSites()
+    .where('_path', 'equals', '/')
+    .andNot('_siteId', 'equals', [NEOLETTER_MAILINGS_SITE_ID, null])
     .toArray()
-    .filter((site) =>
-      baseUrlsFor(site).some((baseUrl) => url.startsWith(baseUrl)),
-    )
-  if (sites.length !== 1) return
-
-  const site = sites[0]
-  const siteId = site?.siteId()
-  if (!site || !siteId) return
-
-  const baseUrl = baseUrlsFor(site)[0]
-  if (!baseUrl) return
-
-  return { baseUrl, siteId }
+    .flatMap((site) => {
+      // null site IDs are excluded by the _siteId query
+      const siteId = site.siteId()!
+      return baseUrlsFor(site).map((baseUrl) => ({ baseUrl, siteId }))
+    })
+    .find(({ baseUrl }) => url.startsWith(baseUrl))
 }
 
 function baseUrlsFor(site: Obj) {
@@ -119,12 +114,6 @@ function getBaseAppUrl(): string | undefined {
 
 function appWebsites() {
   return Obj.onAllSites().where('_contentId', 'equals', rootContentId)
-}
-
-function allWebsites() {
-  return Obj.onAllSites()
-    .where('_path', 'equals', '/')
-    .andNot('_siteId', 'equals', NEOLETTER_MAILINGS_SITE_ID)
 }
 
 function siteHasLanguage(site: Obj, language: string | null) {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -28,6 +28,9 @@ export default defineConfig(({ mode }) => {
     },
     define: {
       'import.meta.env.SCRIVITO_TENANT': JSON.stringify(env.SCRIVITO_TENANT),
+      'import.meta.env.SCRIVITO_ROOT_CONTENT_ID': JSON.stringify(
+        env.SCRIVITO_ROOT_CONTENT_ID,
+      ),
       'import.meta.env.ENABLE_PISA': JSON.stringify(enablePisa),
     },
     optimizeDeps: {


### PR DESCRIPTION
In order to inform the app about the default site and its language versions, a new optional env `SCRIVITO_ROOT_CONTENT_ID` is added.
In order to work properly in a multi-site instance with isolated sites, root pages must have a `baseUrl` set.

### Todo
Isolated sites (or language versions) which share a URL prefix with another site/version don't work yet, e.g.,

```
https://example.com/en
https://example.com/en-US
```
