### PR TITLE
Handle ambiguous base URLs

### DIFF
--- a/src/config/scrivitoSites.ts
+++ b/src/config/scrivitoSites.ts
@@ -72,6 +72,7 @@ function findSiteForUrl(url: string) {
       const siteId = site.siteId()!
       return baseUrlsFor(site).map((baseUrl) => ({ baseUrl, siteId }))
     })
+    .sort((a, b) => b.baseUrl.length - a.baseUrl.length)
     .find(({ baseUrl }) => url.startsWith(baseUrl))
 }
 

--- a/src/config/scrivitoSites.ts
+++ b/src/config/scrivitoSites.ts
@@ -58,7 +58,9 @@ export function siteForUrl(
 }
 
 function languageForUrl(url: string) {
-  const regex = new RegExp(`^${getBaseAppUrl()}\\/(?<lang>[a-z]{2})([?/]|$)`)
+  const regex = new RegExp(
+    `^${getBaseAppUrl()}\\/(?<lang>[a-z]{2}(-[A-Z]{2})?)([?/]|$)`,
+  )
   return regex.exec(url)?.groups?.lang
 }
 


### PR DESCRIPTION
Todo from #518

Also added support for xx-XX language codes for language versions.

I ignored the sort performance assuming the number of sites is smallish and the callback is not called frequently.