### PR TITLE
Bugfix CallbackRequest: If no callback can be found return empty string

### DIFF
--- a/src/Data/CallbackRequest/Pisa/pisaCallbackRequestDataClass.ts
+++ b/src/Data/CallbackRequest/Pisa/pisaCallbackRequestDataClass.ts
@@ -1,4 +1,4 @@
-import { provideDataClass } from 'scrivito'
+import { ClientError, provideDataClass } from 'scrivito'
 import { pisaClient } from '../../pisaClient'
 import { DataIndexResponse, RawItem } from '../../types'
 
@@ -8,10 +8,18 @@ export async function pisaCallbackRequestDataClass() {
   // callback-request is more or less a "singleton". It only offers PUT, GET and DELETE.
   return provideDataClass('CallbackRequest', {
     connection: {
-      index: async () =>
-        ({
-          results: [await callbackRequestClient.get('')],
-        }) as DataIndexResponse,
+      index: async () => {
+        try {
+          return {
+            results: [await callbackRequestClient.get('')],
+          } as DataIndexResponse
+        } catch (error) {
+          if (!(error instanceof ClientError)) throw error
+          if (error.code !== 'record.not_found') throw error
+
+          return { results: [] }
+        }
+      },
       get: () => callbackRequestClient.get(''),
       create: async (data) =>
         callbackRequestClient.put('', { data }) as Promise<RawItem>,

--- a/src/Data/CallbackRequest/Pisa/pisaCallbackRequestDataClass.ts
+++ b/src/Data/CallbackRequest/Pisa/pisaCallbackRequestDataClass.ts
@@ -14,10 +14,14 @@ export async function pisaCallbackRequestDataClass() {
             results: [await callbackRequestClient.get('')],
           } as DataIndexResponse
         } catch (error) {
-          if (!(error instanceof ClientError)) throw error
-          if (error.code !== 'record.not_found') throw error
+          if (
+            error instanceof ClientError &&
+            error.code === 'record.not_found'
+          ) {
+            return { results: [] }
+          }
 
-          return { results: [] }
+          throw error
         }
       },
       get: () => callbackRequestClient.get(''),


### PR DESCRIPTION
With Scrivito 1.43.0-rc1 errors in coonection.index will be thrown again.