### PR TITLE
Replace useDataItem() with useData().dataItem()

### DIFF
--- a/src/Widgets/DataDeleteButtonWidget/DataDeleteButtonWidgetComponent.tsx
+++ b/src/Widgets/DataDeleteButtonWidget/DataDeleteButtonWidgetComponent.tsx
@@ -5,7 +5,7 @@ import {
   currentLanguage,
   navigateTo,
   provideComponent,
-  useDataItem,
+  useData,
 } from 'scrivito'
 import { DataDeleteButtonWidget } from './DataDeleteButtonWidgetClass'
 import { useState } from 'react'
@@ -19,7 +19,7 @@ import { ModalSpinner } from '../../Components/ModalSpinner'
 provideComponent(DataDeleteButtonWidget, ({ widget }) => {
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [showConfirmation, setShowConfirmation] = useState(false)
-  const dataItem = useDataItem()
+  const dataItem = useData().dataItem()
 
   const buttonClassNames = ['btn']
   const cancelButtonClassNames = ['btn']

--- a/src/Widgets/DataFormBooleanWidget/DataFormBooleanWidgetComponent.tsx
+++ b/src/Widgets/DataFormBooleanWidget/DataFormBooleanWidgetComponent.tsx
@@ -2,14 +2,14 @@ import {
   ContentTag,
   InPlaceEditingOff,
   provideComponent,
-  useDataItem,
+  useData,
 } from 'scrivito'
 import { DataFormBooleanWidget } from './DataFormBooleanWidgetClass'
 import { OverlayTrigger, Popover } from 'react-bootstrap'
 import './DataFormBooleanWidget.scss'
 
 provideComponent(DataFormBooleanWidget, ({ widget }) => {
-  const dataItem = useDataItem()
+  const dataItem = useData().dataItem()
 
   const id = ['DataFormBooleanWidget', widget.id(), dataItem?.id()].join('-')
 

--- a/src/Widgets/DataFormInputFieldWidget/DataFormInputFieldWidgetComponent.tsx
+++ b/src/Widgets/DataFormInputFieldWidget/DataFormInputFieldWidgetComponent.tsx
@@ -3,12 +3,12 @@ import {
   ContentTag,
   InPlaceEditingOff,
   provideComponent,
-  useDataItem,
+  useData,
 } from 'scrivito'
 import { DataFormInputFieldWidget } from './DataFormInputFieldWidgetClass'
 
 provideComponent(DataFormInputFieldWidget, ({ widget }) => {
-  const dataItem = useDataItem()
+  const dataItem = useData().dataItem()
 
   const id = ['DataFormInputFieldWidget', widget.id(), dataItem?.id()].join('-')
 

--- a/src/Widgets/DataFormNumberWidget/DataFormNumberWidgetComponent.tsx
+++ b/src/Widgets/DataFormNumberWidget/DataFormNumberWidgetComponent.tsx
@@ -2,14 +2,14 @@ import {
   ContentTag,
   InPlaceEditingOff,
   provideComponent,
-  useDataItem,
+  useData,
 } from 'scrivito'
 
 import { OverlayTrigger, Popover } from 'react-bootstrap'
 import { DataFormNumberWidget } from './DataFormNumberWidgetClass'
 
 provideComponent(DataFormNumberWidget, ({ widget }) => {
-  const dataItem = useDataItem()
+  const dataItem = useData().dataItem()
 
   const id = ['DataFormNumberWidget', widget.id(), dataItem?.id()].join('-')
 

--- a/src/Widgets/DataMessageWidget/DataMessageWidgetComponent.tsx
+++ b/src/Widgets/DataMessageWidget/DataMessageWidgetComponent.tsx
@@ -3,7 +3,7 @@ import {
   DataItem,
   WidgetTag,
   provideComponent,
-  useDataItem,
+  useData,
 } from 'scrivito'
 import { DataMessageWidget } from './DataMessageWidgetClass'
 import { User } from '../../Data/User/UserDataClass'
@@ -15,7 +15,7 @@ import { DataBinaryImage } from '../../Components/DataBinaryImage'
 import { ensureString } from '../../utils/ensureString'
 
 provideComponent(DataMessageWidget, ({ widget }) => {
-  const dataItem = useDataItem()
+  const dataItem = useData().dataItem()
   const createdBy = ensureString(dataItem?.get('createdBy'))
 
   const user: DataItem | null = createdBy ? User.get(createdBy) : null
@@ -57,7 +57,7 @@ function getImage({
   dataItem,
   user,
 }: {
-  dataItem?: DataItem
+  dataItem: DataItem | null
   user?: DataItem | null
 }): DataBinary {
   if (!dataItem) {


### PR DESCRIPTION
useDataItem() might not return the most "top" item on the stack, if there is e.g. a "DataScope" on top of the stack. "useData()" will always return the newest thing on top of the stack, e.g. a "dataItem" or a "dataScope".

Follow up of https://github.com/Scrivito/scrivito-portal-app/pull/547.