### PR TITLE
DataFormNumberWidget: Use bootstrap styling for input field

### DIFF
--- a/src/Widgets/DataFormNumberWidget/DataFormNumberWidgetComponent.tsx
+++ b/src/Widgets/DataFormNumberWidget/DataFormNumberWidgetComponent.tsx
@@ -60,6 +60,7 @@ provideComponent(DataFormNumberWidget, ({ widget }) => {
       ) : null}
       <br />
       <input
+        className="form-control"
         defaultValue={defaultValue}
         id={id}
         name={attributeName}


### PR DESCRIPTION
Previously:
<img width="748" alt="Screenshot 2024-08-05 at 10 17 17" src="https://github.com/user-attachments/assets/2692d12a-e260-44a3-89e2-455594b10e25">


Now:
<img width="749" alt="Screenshot 2024-08-05 at 10 17 31" src="https://github.com/user-attachments/assets/fe3d2520-8988-4d99-8218-dba65d300cd6">

