### PR TITLE
[circle] Use node version 18.18.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ jobs:
       npm-run-command:
         type: string
     docker:
-      - image: cimg/node:18.17
+      - image: cimg/node:18.18
     steps:
       - checkout
       - run: npm ci


### PR DESCRIPTION
Otherwise some package will complain, that they are not compatible.

Avoids "Unsupported engine" warnings, such as https://app.circleci.com/pipelines/github/Scrivito/scrivito-portal-app/1709/workflows/67bed7bd-0d09-4639-bfde-8061eacc69be/jobs/5272?invite=true#step-102-0_40