### PR TITLE
Drop hardcoded site ID "default"

### DIFF
--- a/src/Data/pisaClient.ts
+++ b/src/Data/pisaClient.ts
@@ -3,7 +3,7 @@ import { isHomepage } from '../Objs/Homepage/HomepageObjClass'
 
 export async function pisaUrl(): Promise<string> {
   const defaultRoot = await load(() =>
-    Obj.onAllSites().get(import.meta.env.SCRIVITO_ROOT_CONTENT_ID),
+    Obj.onAllSites().get(import.meta.env.SCRIVITO_ROOT_OBJ_ID),
   )
   if (!isHomepage(defaultRoot)) return never()
 

--- a/src/Data/pisaClient.ts
+++ b/src/Data/pisaClient.ts
@@ -2,7 +2,9 @@ import { Obj, createRestApiClient, currentLanguage, load } from 'scrivito'
 import { isHomepage } from '../Objs/Homepage/HomepageObjClass'
 
 export async function pisaUrl(): Promise<string> {
-  const defaultRoot = await load(() => Obj.onSite('default').root())
+  const defaultRoot = await load(() =>
+    Obj.onAllSites().get(import.meta.env.SCRIVITO_ROOT_CONTENT_ID),
+  )
   if (!isHomepage(defaultRoot)) return never()
 
   const url = defaultRoot.get('pisaUrl')

--- a/src/Objs/Homepage/HomepageEditingConfig.ts
+++ b/src/Objs/Homepage/HomepageEditingConfig.ts
@@ -57,7 +57,9 @@ provideEditingConfig(Homepage, {
       properties: [
         'contentTitle',
         'baseUrl',
-        site.siteId() === 'default' && site.path() === '/' ? 'pisaUrl' : null,
+        site.id() === import.meta.env.SCRIVITO_ROOT_CONTENT_ID
+          ? 'pisaUrl'
+          : null,
         'siteLogoDark',
         'siteFavicon',
         'siteLanguageIcon',

--- a/src/Objs/Homepage/HomepageEditingConfig.ts
+++ b/src/Objs/Homepage/HomepageEditingConfig.ts
@@ -57,9 +57,7 @@ provideEditingConfig(Homepage, {
       properties: [
         'contentTitle',
         'baseUrl',
-        site.id() === import.meta.env.SCRIVITO_ROOT_CONTENT_ID
-          ? 'pisaUrl'
-          : null,
+        site.id() === import.meta.env.SCRIVITO_ROOT_OBJ_ID ? 'pisaUrl' : null,
         'siteLogoDark',
         'siteFavicon',
         'siteLanguageIcon',

--- a/src/config/scrivitoSites.ts
+++ b/src/config/scrivitoSites.ts
@@ -15,7 +15,7 @@ const origin =
     ? window.location.origin
     : ensureString(import.meta.env.SCRIVITO_ORIGIN)
 
-const rootContentId = ensureString(import.meta.env.SCRIVITO_ROOT_CONTENT_ID)
+const rootContentId = ensureString(import.meta.env.SCRIVITO_ROOT_OBJ_ID)
 
 const NEOLETTER_MAILINGS_SITE_ID = 'mailing-app'
 

--- a/src/config/scrivitoSites.ts
+++ b/src/config/scrivitoSites.ts
@@ -15,8 +15,7 @@ const origin =
     ? window.location.origin
     : ensureString(import.meta.env.SCRIVITO_ORIGIN)
 
-const rootContentId =
-  ensureString(import.meta.env.SCRIVITO_ROOT_CONTENT_ID) || 'c2a0aab78be05a4e'
+const rootContentId = ensureString(import.meta.env.SCRIVITO_ROOT_CONTENT_ID)
 
 const NEOLETTER_MAILINGS_SITE_ID = 'mailing-app'
 

--- a/src/config/scrivitoSites.ts
+++ b/src/config/scrivitoSites.ts
@@ -15,7 +15,8 @@ const origin =
     ? window.location.origin
     : ensureString(import.meta.env.SCRIVITO_ORIGIN)
 
-const rootContentId = ensureString(import.meta.env.SCRIVITO_ROOT_OBJ_ID)
+const rootContentId =
+  ensureString(import.meta.env.SCRIVITO_ROOT_OBJ_ID) || undefined
 
 const NEOLETTER_MAILINGS_SITE_ID = 'mailing-app'
 
@@ -47,7 +48,7 @@ export function siteForUrl(
 
   const language = languageForUrl(url)
   const languageSite = language
-    ? appWebsites().and('_language', 'equals', language).first()
+    ? appWebsites()?.and('_language', 'equals', language).first()
     : undefined
   const languageSiteId = languageSite?.siteId()
 
@@ -90,7 +91,7 @@ function baseUrlsFor(site: Obj) {
 export async function ensureSiteIsPresent() {
   if ((await load(currentSiteId)) === null) {
     navigateTo(() => {
-      const websites = appWebsites().toArray()
+      const websites = appWebsites()?.toArray() || []
       const preferredLanguageOrder = [...window.navigator.languages, 'en', null]
 
       for (const language of preferredLanguageOrder) {
@@ -110,7 +111,10 @@ function getBaseAppUrl(): string {
 }
 
 function appWebsites() {
-  return Obj.onAllSites().where('_contentId', 'equals', rootContentId)
+  const contentId = rootContentId
+  return contentId
+    ? Obj.onAllSites().where('_contentId', 'equals', contentId)
+    : undefined
 }
 
 function siteHasLanguage(site: Obj, language: string | null) {

--- a/src/config/scrivitoSites.ts
+++ b/src/config/scrivitoSites.ts
@@ -15,9 +15,6 @@ const origin =
     ? window.location.origin
     : ensureString(import.meta.env.SCRIVITO_ORIGIN)
 
-const rootContentId =
-  ensureString(import.meta.env.SCRIVITO_ROOT_OBJ_ID) || undefined
-
 const NEOLETTER_MAILINGS_SITE_ID = 'mailing-app'
 
 export function baseUrlForSite(siteId: string): string | undefined {
@@ -28,7 +25,7 @@ export function baseUrlForSite(siteId: string): string | undefined {
   const siteRoot = Obj.onSite(siteId).root()
   if (!siteRoot) return
 
-  if (siteRoot.contentId() !== rootContentId) {
+  if (siteRoot.contentId() !== rootContentId()) {
     return baseUrlsFor(siteRoot)[0]
   }
 
@@ -111,10 +108,16 @@ function getBaseAppUrl(): string {
 }
 
 function appWebsites() {
-  const contentId = rootContentId
+  const contentId = rootContentId()
   return contentId
     ? Obj.onAllSites().where('_contentId', 'equals', contentId)
     : undefined
+}
+
+function rootContentId() {
+  return Obj.onAllSites()
+    .get(import.meta.env.SCRIVITO_ROOT_OBJ_ID)
+    ?.contentId()
 }
 
 function siteHasLanguage(site: Obj, language: string | null) {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -30,7 +30,7 @@ export default defineConfig(({ mode }) => {
       'import.meta.env.SCRIVITO_ORIGIN': JSON.stringify(scrivitoOrigin(env)),
       'import.meta.env.SCRIVITO_TENANT': JSON.stringify(env.SCRIVITO_TENANT),
       'import.meta.env.SCRIVITO_ROOT_CONTENT_ID': JSON.stringify(
-        env.SCRIVITO_ROOT_CONTENT_ID,
+        env.SCRIVITO_ROOT_CONTENT_ID || 'c2a0aab78be05a4e',
       ),
       'import.meta.env.ENABLE_PISA': JSON.stringify(enablePisa),
     },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -29,8 +29,8 @@ export default defineConfig(({ mode }) => {
     define: {
       'import.meta.env.SCRIVITO_ORIGIN': JSON.stringify(scrivitoOrigin(env)),
       'import.meta.env.SCRIVITO_TENANT': JSON.stringify(env.SCRIVITO_TENANT),
-      'import.meta.env.SCRIVITO_ROOT_CONTENT_ID': JSON.stringify(
-        env.SCRIVITO_ROOT_CONTENT_ID || 'c2a0aab78be05a4e',
+      'import.meta.env.SCRIVITO_ROOT_OBJ_ID': JSON.stringify(
+        env.SCRIVITO_ROOT_OBJ_ID || 'c2a0aab78be05a4e',
       ),
       'import.meta.env.ENABLE_PISA': JSON.stringify(enablePisa),
     },


### PR DESCRIPTION
Instead of `SCRIVITO_ROOT_CONTENT_ID` we now configure `SCRIVITO_ROOT_OBJ_ID`. This allows to infer both
* the default site ID and
* the root content ID

from the obj, which was not possible the other way around.

This makes it easier to integrate the app into existing instances that already use the site ID `default`.