### PR TITLE
Data: Drop "string" attribute workaround

### DIFF
--- a/src/Data/Contract/ContractDataClass.ts
+++ b/src/Data/Contract/ContractDataClass.ts
@@ -3,7 +3,6 @@ import { localContractDataClass } from './LocalStorage/localContractDataClass'
 import { pisaContractDataClass } from './Pisa/pisaContractDataClass'
 
 const attributes: DataClassAttributes = {
-  agent: 'string', // TODO: convert to reference, once fully available
   category: 'string', // TODO: convert to enum, once fully available
   internalDepartment: 'string',
   keyword: 'string',

--- a/src/Data/ContractDocument/ContractDocumentDataClass.ts
+++ b/src/Data/ContractDocument/ContractDocumentDataClass.ts
@@ -2,10 +2,7 @@ import { DataClassAttributes } from '../types'
 import { localStorageContractDocumentDataClass } from './LocalStorage/localStorageContractDocumentDataClass'
 import { pisaContractDocumentDataClass } from './Pisa/pisaContractDocumentDataClass'
 
-const attributes: DataClassAttributes = {
-  contractId: 'string', // TODO: convert to reference, once fully available
-  documentId: 'string', // TODO: convert to reference, once fully available
-}
+const attributes: DataClassAttributes = {}
 
 export const ContractDocument = import.meta.env.ENABLE_PISA
   ? pisaContractDocumentDataClass(attributes)

--- a/src/Data/CurrentUser/CurrentUserDataItem.ts
+++ b/src/Data/CurrentUser/CurrentUserDataItem.ts
@@ -16,10 +16,7 @@ export const CurrentUser = provideDataItem('CurrentUser', {
     name: 'string',
     phoneNumber: 'string',
     picture: 'string',
-    pisaUserId: 'string', // TODO: convert to reference, once fully available
-    salesUserId: 'string', // TODO: convert to reference, once fully available
     salutation: 'string',
-    serviceUserId: 'string', // TODO: convert to reference, once fully available
   },
   connection: {
     async get() {

--- a/src/Data/Event/EventDataClass.ts
+++ b/src/Data/Event/EventDataClass.ts
@@ -9,7 +9,6 @@ const attributes: DataClassAttributes = {
   location: 'string',
   number: 'string',
   organizer: 'string',
-  responsibleAgent: 'string', // TODO: convert to reference, once fully available
   status: 'string', // TODO: convert to enum, once fully available
   url: 'string',
 }

--- a/src/Data/EventDocument/EventDocumentDataClass.ts
+++ b/src/Data/EventDocument/EventDocumentDataClass.ts
@@ -2,10 +2,7 @@ import { DataClassAttributes } from '../types'
 import { localStorageEventDocumentDataClass } from './LocalStorage/localStorageEventDocumentDataClass'
 import { pisaEventDocumentDataClass } from './Pisa/pisaEventDocumentDataClass'
 
-const attributes: DataClassAttributes = {
-  documentId: 'string', // TODO: convert to reference, once fully available
-  eventId: 'string', // TODO: convert to reference, once fully available
-}
+const attributes: DataClassAttributes = {}
 
 export const EventDocument = import.meta.env.ENABLE_PISA
   ? pisaEventDocumentDataClass(attributes)

--- a/src/Data/EventRegistration/EventRegistrationDataClass.ts
+++ b/src/Data/EventRegistration/EventRegistrationDataClass.ts
@@ -2,9 +2,7 @@ import { DataClassAttributes } from '../types'
 import { localStorageEventRegistrationDataClass } from './LocalStorage/localStorageEventRegistrationDataClass'
 import { pisaEventRegistrationDataClass } from './Pisa/pisaEventRegistrationDataClass'
 
-const attributes: DataClassAttributes = {
-  eventId: 'string', // TODO: convert to reference, once fully available
-}
+const attributes: DataClassAttributes = {}
 
 export const EventRegistration = import.meta.env.ENABLE_PISA
   ? pisaEventRegistrationDataClass(attributes)

--- a/src/Data/Message/MessageDataClass.ts
+++ b/src/Data/Message/MessageDataClass.ts
@@ -3,8 +3,6 @@ import { localStorageMessageDataClass } from './LocalStorage/localStorageMessage
 import { pisaMessageDataClass } from './Pisa/pisaMessageDataClass'
 
 const attributes: DataClassAttributes = {
-  createdBy: 'string', // TODO: convert to reference, once fully available
-  subjectId: 'string', // TODO: convert to reference, once fully available
   text: 'string',
 }
 

--- a/src/Data/Order/OrderDataClass.ts
+++ b/src/Data/Order/OrderDataClass.ts
@@ -3,7 +3,6 @@ import { localStorageOrderDataClass } from './LocalStorage/localStorageOrderData
 import { pisaOrderDataClass } from './Pisa/pisaOrderDataClass'
 
 const attributes: DataClassAttributes = {
-  commercialAgent: 'string', // TODO: convert to reference, once fully available
   customer: 'string',
   description: 'string',
   keyword: 'string',
@@ -11,7 +10,6 @@ const attributes: DataClassAttributes = {
   number: 'string',
   salesPartner: 'string',
   status: 'string', // TODO: convert to enum, once fully available
-  technicalAgent: 'string', // TODO: convert to reference, once fully available
   termsOfDelivery: 'string', // TODO: convert to enum, once fully available
   termsOfPayment: 'string', // TODO: convert to enum, once fully available
   totalPriceCurrency: 'string',

--- a/src/Data/OrderDocument/OrderDocumentDataClass.ts
+++ b/src/Data/OrderDocument/OrderDocumentDataClass.ts
@@ -2,10 +2,7 @@ import { DataClassAttributes } from '../types'
 import { localStorageOrderDocumentDataClass } from './LocalStorage/localStorageOrderDocumentDataClass'
 import { pisaOrderDocumentDataClass } from './Pisa/pisaOrderDocumentDataClass'
 
-const attributes: DataClassAttributes = {
-  orderId: 'string', // TODO: convert to reference, once fully available
-  documentId: 'string', // TODO: convert to reference, once fully available
-}
+const attributes: DataClassAttributes = {}
 
 export const OrderDocument = import.meta.env.ENABLE_PISA
   ? pisaOrderDocumentDataClass(attributes)

--- a/src/Data/OrderRequest/OrderRequestDataClass.ts
+++ b/src/Data/OrderRequest/OrderRequestDataClass.ts
@@ -2,9 +2,7 @@ import { DataClassAttributes } from '../types'
 import { localStorageOrderRequestDataClass } from './LocalStorage/localStorageOrderRequestDataClass'
 import { pisaOrderRequestDataClass } from './Pisa/pisaOrderRequestDataClass'
 
-const attributes: DataClassAttributes = {
-  quoteId: 'string', // TODO: convert to reference, once fully available
-}
+const attributes: DataClassAttributes = {}
 
 export const OrderRequest = import.meta.env.ENABLE_PISA
   ? pisaOrderRequestDataClass(attributes)

--- a/src/Data/Quote/QuoteDataClass.ts
+++ b/src/Data/Quote/QuoteDataClass.ts
@@ -3,7 +3,6 @@ import { localQuoteDataClass } from './LocalStorage/localQuoteDataClass'
 import { pisaQuoteDataClass } from './Pisa/pisaQuoteDataClass'
 
 const attributes: DataClassAttributes = {
-  commercialAgent: 'string', // TODO: convert to reference, once fully available
   customer: 'string',
   description: 'string',
   keyword: 'string',
@@ -11,7 +10,6 @@ const attributes: DataClassAttributes = {
   number: 'string',
   salesPartner: 'string',
   status: 'string', // TODO: convert to enum, once fully available
-  technicalAgent: 'string', // TODO: convert to reference, once fully available
   termsOfDelivery: 'string', // TODO: convert to enum, once fully available
   termsOfPayment: 'string', // TODO: convert to enum, once fully available
   totalPriceCurrency: 'string',

--- a/src/Data/QuoteDocument/QuoteDocumentDataClass.ts
+++ b/src/Data/QuoteDocument/QuoteDocumentDataClass.ts
@@ -2,10 +2,7 @@ import { DataClassAttributes } from '../types'
 import { localStorageQuoteDocumentDataClass } from './LocalStorage/localStorageQuoteDocumentDataClass'
 import { pisaQuoteDocumentDataClass } from './Pisa/pisaQuoteDocumentDataClass'
 
-const attributes: DataClassAttributes = {
-  quoteId: 'string', // TODO: convert to reference, once fully available
-  documentId: 'string', // TODO: convert to reference, once fully available
-}
+const attributes: DataClassAttributes = {}
 
 export const QuoteDocument = import.meta.env.ENABLE_PISA
   ? pisaQuoteDocumentDataClass(attributes)

--- a/src/Data/ServiceObject/ServiceObjectDataClass.ts
+++ b/src/Data/ServiceObject/ServiceObjectDataClass.ts
@@ -13,9 +13,7 @@ const attributes: DataClassAttributes = {
   locationStreet: 'string',
   modelNumber: 'string',
   number: 'string',
-  parentId: 'string', // TODO: convert to reference, once fully available
   product: 'string',
-  responsibleAgent: 'string', // TODO: convert to reference, once fully available
   serialNumber: 'string',
   status: 'string', // TODO: convert to enum, once fully available
   supplier: 'string',

--- a/src/Data/ServiceObjectDocument/ServiceObjectDocumentDataClass.ts
+++ b/src/Data/ServiceObjectDocument/ServiceObjectDocumentDataClass.ts
@@ -2,10 +2,7 @@ import { DataClassAttributes } from '../types'
 import { localStorageServiceObjectDocumentDataClass } from './LocalStorage/localStorageServiceObjectDocumentDataClass'
 import { pisaServiceObjectDocumentDataClass } from './Pisa/pisaServiceObjectDocumentDataClass'
 
-const attributes: DataClassAttributes = {
-  documentId: 'string', // TODO: convert to reference, once fully available
-  serviceObjectId: 'string', // TODO: convert to reference, once fully available
-}
+const attributes: DataClassAttributes = {}
 
 export const ServiceObjectDocument = import.meta.env.ENABLE_PISA
   ? pisaServiceObjectDocumentDataClass(attributes)

--- a/src/Data/Ticket/TicketDataClass.ts
+++ b/src/Data/Ticket/TicketDataClass.ts
@@ -3,11 +3,9 @@ import { localStorageTicketDataClass } from './LocalStorage/localStorageTicketDa
 import { pisaTicketDataClass } from './Pisa/pisaTicketDataClass'
 
 const attributes: DataClassAttributes = {
-  createdBy: 'string', // TODO: convert to reference, once fully available
   description: 'string',
   number: 'string',
   referenceNumber: 'string',
-  responsibleAgent: 'string', // TODO: convert to reference, once fully available
   status: 'string', // TODO: convert to enum, once fully available
   title: 'string',
   type: 'string', // TODO: convert to enum, once fully available


### PR DESCRIPTION
It does not work properly. E.g. if an attribute is empty (null) the SDK automatically converts this to an empty string ("") and then complains, that an empty string is not a valid ID.