### PR TITLE
Top nav selector fixes

### DIFF
--- a/src/Widgets/TopNavigationWidget/TopNavigationWidget.scss
+++ b/src/Widgets/TopNavigationWidget/TopNavigationWidget.scss
@@ -1,0 +1,22 @@
+.top-navigation-widget {
+  z-index: 3;
+
+  /* two color top navbar  */
+  &:after {
+    background: var(--light-grey);
+    content: '';
+    display: block;
+    position: absolute;
+    top: 0;
+    height: 38px;
+    z-index: -1;
+    right: 0;
+    left: 0;
+    pointer-events: none;
+  }
+
+  &.bg-primary:after,
+  &.bg-secondary:after {
+    display: none;
+  }
+}

--- a/src/Widgets/TopNavigationWidget/TopNavigationWidgetComponent.tsx
+++ b/src/Widgets/TopNavigationWidget/TopNavigationWidgetComponent.tsx
@@ -11,9 +11,13 @@ provideComponent(TopNavigationWidget, ({ widget }) => {
   const root = Obj.root()
   if (!isHomepage(root)) return null
 
+  const classNames = ['top-navigation-widget']
+
   if (currentPage()?.get('showAsLandingPage')) {
+    classNames.push('bg-primary', 'pb-4')
+
     return (
-      <WidgetTag tag="section" className="bg-primary pb-4">
+      <WidgetTag tag="section" className={classNames.join(' ')}>
         <div className="container">
           <Navbar expand="lg" collapseOnSelect>
             <Brand root={root} linkClassName="navbar-brand m-auto pt-3" />
@@ -23,11 +27,10 @@ provideComponent(TopNavigationWidget, ({ widget }) => {
     )
   }
 
+  if (widget.get('slimDesign')) classNames.push('slim-nav')
+
   return (
-    <WidgetTag
-      tag="section"
-      className={widget.get('slimDesign') ? 'slim-nav' : ''}
-    >
+    <WidgetTag tag="section" className={classNames.join(' ')}>
       <div className="container">
         <Navbar expand="lg" collapseOnSelect>
           <Brand root={root} linkClassName="navbar-brand" />

--- a/src/Widgets/TopNavigationWidget/TopNavigationWidgetComponent.tsx
+++ b/src/Widgets/TopNavigationWidget/TopNavigationWidgetComponent.tsx
@@ -6,6 +6,7 @@ import { Brand } from './SubComponents/Brand'
 import { MainNavigation } from './SubComponents/MainNavigation'
 import { MetaNavigation } from './SubComponents/MetaNavigation'
 import { isHomepage } from '../../Objs/Homepage/HomepageObjClass'
+import './TopNavigationWidget.scss'
 
 provideComponent(TopNavigationWidget, ({ widget }) => {
   const root = Obj.root()

--- a/src/assets/stylesheets/index.scss
+++ b/src/assets/stylesheets/index.scss
@@ -1777,29 +1777,6 @@ header .navbar.navbar-expand-lg {
   margin: 0;
 }
 
-/* two color top navbar for tynacoon
- =================================================================== */
-header:first-of-type section {
-  overflow: visible;
-  z-index: 3;
-}
-header:first-of-type section:after {
-  background: var(--light-grey);
-  content: '';
-  display: block;
-  position: absolute;
-  top: 0;
-  height: 38px;
-  z-index: -1;
-  right: 0;
-  left: 0;
-  pointer-events: none;
-}
-header:first-of-type section.bg-primary:after,
-header:first-of-type section.bg-secondary:after {
-  display: none;
-}
-
 /* breadcrumb
  =================================================================== */
 


### PR DESCRIPTION
The previous position-based selectors caused two issues:

* The logo did not overlap if the nav header had a section below the top nav
* All sections in the top nav had a grey bar

Apart from not matching sections that are not actual top-nav sections, the selector matches exactly as before, including the landing page layout and slim nav. Not fully sure if this is intended, but it worked before and still works.