### PR TITLE
Harmonize spacing in sidebar extensions

### DIFF
--- a/src/Objs/Homepage/SiteColorsPicker.scss
+++ b/src/Objs/Homepage/SiteColorsPicker.scss
@@ -44,8 +44,6 @@
   }
 
   &.scrivito_dark {
-    padding: 7px !important;
-
     .rcp-root {
       --rcp-background-color: rgba(222, 222, 222, 0.1);
       --rcp-field-input-color: #eee;

--- a/src/assets/stylesheets/scrivitoExtensions.scss
+++ b/src/assets/stylesheets/scrivitoExtensions.scss
@@ -26,6 +26,15 @@ body {
   [data-scrivito-editors-placeholder]:empty:not(:focus):before {
     color: #aaa !important;
   }
+
+  &.scrivito_detail_content,
+  .scrivito_detail_content {
+    padding: 7px;
+
+    .row {
+      --bs-gutter-x: 7px;
+    }
+  }
 }
 
 // --------------------------------------------------------------- //


### PR DESCRIPTION
This also prevents scrollbars if the OS is set to always show scrollbars. If the gutter is wider than the padding a row will have x-overflow.

Reported here: https://infopark.slack.com/archives/C05FSSUAKUP/p1723627150805279

### Before/After

<img width="553" alt="image" src="https://github.com/user-attachments/assets/d7659c1a-54fa-4245-ba9e-b11161bf7a11">
