### PR TITLE
Add `treatLocalhostLike`

### DIFF
--- a/src/config/scrivito.ts
+++ b/src/config/scrivito.ts
@@ -13,6 +13,7 @@ export function configureScrivito(options?: { priority?: 'background' }) {
     siteForUrl,
     strictSearchOperators: true,
     tenant: scrivitoTenantId(),
+    treatLocalhostLike: 'https://scrivito-portal-app.pages.dev',
     // @ts-expect-error // TODO: Remove later on
     unstable: {
       assetUrlBase: 'http://localhost:8091',


### PR DESCRIPTION
Make sure the Portal-App only gets an app token (`stas_*`) from IAM – not a product token (`st_*`) (caused by the `X-Treat-Localhost-Like` header of the UI's webpack proxy).

This fixes a deviation from the production env, for a local portal-app running in a local UI.

Outcome of https://infopark.slack.com/archives/G011EJEGKD5/p1721287390884569