### PR TITLE
Brand logo size improvements

### DIFF
--- a/src/assets/stylesheets/index.scss
+++ b/src/assets/stylesheets/index.scss
@@ -1256,6 +1256,7 @@ section:focus >,
   }
   .navbar-brand-logo {
     max-width: 155px;
+    min-height: 45px;
   }
   .navbar-meta .nav-link {
     padding: 17px;
@@ -1318,6 +1319,8 @@ section:focus >,
 .navbar-brand-logo {
   margin: auto;
   max-width: 135px;
+  min-height: 37px;
+  object-fit: contain;
 }
 .navbar {
   padding: 0;

--- a/src/assets/stylesheets/index.scss
+++ b/src/assets/stylesheets/index.scss
@@ -1255,6 +1255,7 @@ section:focus >,
     box-shadow: none;
   }
   .navbar-brand-logo {
+    max-height: 100%;
     max-width: 155px;
     min-height: 45px;
   }

--- a/src/assets/stylesheets/index.scss
+++ b/src/assets/stylesheets/index.scss
@@ -1320,6 +1320,7 @@ section:focus >,
 .navbar-brand-logo {
   margin: auto;
   max-width: 135px;
+  max-height: 81px;
   min-height: 37px;
   object-fit: contain;
 }


### PR DESCRIPTION
The 1st commit fixes SVG icons with unknown dimensions:

<img width="476" alt="image" src="https://github.com/user-attachments/assets/d69b82d0-1d4b-4317-8d50-dd89b2f7ffa4">

---

The 2nd commit fixes the slim nav for icons with a large height. It looks interesting but because we don't have the flap background as in the full nav I assume this was not intended:

<img width="476" alt="image" src="https://github.com/user-attachments/assets/51f7566c-69e5-43bb-ae1a-abbe3266cd05">
