### PR TITLE
DataFormUploadWidget: Drag 'n' drop, preview and file size limit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "react-color-palette": "^7.2.2",
         "react-dom": "^18.3.1",
         "react-draggable": "^4.4.6",
+        "react-dropzone": "^14.2.3",
         "react-helmet-async": "^2.0.5",
         "react-toastify": "^10.0.5",
         "scrivito": "^1.43.0",
@@ -2305,6 +2306,14 @@
       "integrity": "sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==",
       "dev": true
     },
+    "node_modules/attr-accept": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/attr-accept/-/attr-accept-2.2.2.tgz",
+      "integrity": "sha512-7prDjvt9HmqiZ0cl5CRjtS84sEyhsHP2coDkaZKRKVfCDo9s7iw7ChVmar78Gu9pC4SoR/28wFu/G5JJhTnqEg==",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/available-typed-arrays": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
@@ -4506,6 +4515,17 @@
       },
       "engines": {
         "node": "^10.12.0 || >=12.0.0"
+      }
+    },
+    "node_modules/file-selector": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/file-selector/-/file-selector-0.6.0.tgz",
+      "integrity": "sha512-QlZ5yJC0VxHxQQsQhXvBaC7VRJ2uaxTf+Tfpu4Z/OcVQJVpZO+DGU0rkoVW5ce2SccxugvpBJoMvUs59iILYdw==",
+      "dependencies": {
+        "tslib": "^2.4.0"
+      },
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/fill-range": {
@@ -8324,6 +8344,22 @@
       "peerDependencies": {
         "react": ">= 16.3.0",
         "react-dom": ">= 16.3.0"
+      }
+    },
+    "node_modules/react-dropzone": {
+      "version": "14.2.3",
+      "resolved": "https://registry.npmjs.org/react-dropzone/-/react-dropzone-14.2.3.tgz",
+      "integrity": "sha512-O3om8I+PkFKbxCukfIR3QAGftYXDZfOE2N1mr/7qebQJHs7U+/RSL/9xomJNpRg9kM5h9soQSdf0Gc7OHF5Fug==",
+      "dependencies": {
+        "attr-accept": "^2.2.2",
+        "file-selector": "^0.6.0",
+        "prop-types": "^15.8.1"
+      },
+      "engines": {
+        "node": ">= 10.13"
+      },
+      "peerDependencies": {
+        "react": ">= 16.8 || 18.0.0"
       }
     },
     "node_modules/react-fast-compare": {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "react-color-palette": "^7.2.2",
     "react-dom": "^18.3.1",
     "react-draggable": "^4.4.6",
+    "react-dropzone": "^14.2.3",
     "react-helmet-async": "^2.0.5",
     "react-toastify": "^10.0.5",
     "scrivito": "^1.43.0",

--- a/src/Components/Attachment.tsx
+++ b/src/Components/Attachment.tsx
@@ -5,8 +5,10 @@ import { FullDataBinary, dataBinaryToUrl } from '../utils/dataBinaryToUrl'
 
 export const Attachment = connect(function Attachment({
   attachment,
+  readonly,
 }: {
   attachment: FullDataBinary
+  readonly?: boolean
 }) {
   const [binaryUrl, setBinaryUrl] = useState<string | undefined>(undefined)
   const [trigger, setTrigger] = useState<number>(0)
@@ -23,12 +25,8 @@ export const Attachment = connect(function Attachment({
     }
   }, [attachment, trigger])
 
-  return (
-    <a
-      href={binaryUrl}
-      className="box-attachment"
-      title={`Download ${attachment.filename}`}
-    >
+  const content = (
+    <>
       <div className="box-preview">
         <BoxPreviewContent binaryUrl={binaryUrl} attachment={attachment} />
       </div>
@@ -40,6 +38,18 @@ export const Attachment = connect(function Attachment({
           })}
         </span>
       </div>
+    </>
+  )
+
+  return readonly ? (
+    <div className="box-attachment">{content}</div>
+  ) : (
+    <a
+      href={binaryUrl}
+      className="box-attachment"
+      title={`Download ${attachment.filename}`}
+    >
+      {content}
     </a>
   )
 })

--- a/src/Components/Attachment.tsx
+++ b/src/Components/Attachment.tsx
@@ -1,0 +1,70 @@
+import prettyBytes from 'pretty-bytes'
+import { useState, useEffect } from 'react'
+import { connect, currentLanguage } from 'scrivito'
+import { FullDataBinary, dataBinaryToUrl } from '../utils/dataBinaryToUrl'
+
+export const Attachment = connect(function Attachment({
+  attachment,
+}: {
+  attachment: FullDataBinary
+}) {
+  const [binaryUrl, setBinaryUrl] = useState<string | undefined>(undefined)
+  const [trigger, setTrigger] = useState<number>(0)
+
+  useEffect(() => {
+    let timeoutId: NodeJS.Timeout
+    dataBinaryToUrl(attachment).then(({ url, maxAge }) => {
+      setBinaryUrl(url)
+      timeoutId = setTimeout(() => setTrigger(Date.now()), maxAge * 1000)
+    })
+
+    return () => {
+      if (timeoutId) clearTimeout(timeoutId)
+    }
+  }, [attachment, trigger])
+
+  return (
+    <a
+      href={binaryUrl}
+      className="box-attachment"
+      title={`Download ${attachment.filename}`}
+    >
+      <div className="box-preview">
+        <BoxPreviewContent binaryUrl={binaryUrl} attachment={attachment} />
+      </div>
+      <div className="box-meta">
+        <span className="box-name">{attachment.filename}</span>
+        <span className="box-size">
+          {prettyBytes(attachment.contentLength, {
+            locale: currentLanguage() ?? 'en',
+          })}
+        </span>
+      </div>
+    </a>
+  )
+})
+
+function BoxPreviewContent({
+  binaryUrl,
+  attachment,
+}: {
+  binaryUrl?: string
+  attachment: FullDataBinary
+}) {
+  if (binaryUrl && attachment.contentType.startsWith('image/')) {
+    return <img src={binaryUrl} alt="" />
+  }
+
+  let iconName = 'bi-file-earmark'
+  const filename = attachment.filename
+  if (filename.endsWith('.pdf')) iconName = 'bi-filetype-pdf'
+  if (filename.endsWith('.docx')) iconName = 'bi-filetype-docx'
+  if (filename.endsWith('.doc')) iconName = 'bi-filetype-doc'
+  if (filename.endsWith('.csv')) iconName = 'bi-filetype-csv'
+  if (filename.endsWith('.json')) iconName = 'bi-filetype-json'
+  if (filename.endsWith('.xml')) iconName = 'bi-filetype-xml'
+  if (filename.endsWith('.txt')) iconName = 'bi-filetype-txt'
+  if (filename.endsWith('.md')) iconName = 'bi-filetype-md'
+
+  return <i className={`bi ${iconName}`}></i>
+}

--- a/src/Components/Attachment.tsx
+++ b/src/Components/Attachment.tsx
@@ -47,7 +47,7 @@ export const Attachment = connect(function Attachment({
     <a
       href={binaryUrl}
       className="box-attachment"
-      title={`Download ${attachment.filename}`}
+      title={getDownloadMessage(attachment.filename)}
     >
       {content}
     </a>
@@ -77,4 +77,13 @@ function BoxPreviewContent({
   if (filename.endsWith('.md')) iconName = 'bi-filetype-md'
 
   return <i className={`bi ${iconName}`}></i>
+}
+
+function getDownloadMessage(subject: string) {
+  switch (currentLanguage()) {
+    case 'de':
+      return `${subject} herunterladen`
+    default:
+      return `Download ${subject}`
+  }
 }

--- a/src/Widgets/DataAttachmentsWidget/DataAttachmentsWidgetComponent.tsx
+++ b/src/Widgets/DataAttachmentsWidget/DataAttachmentsWidgetComponent.tsx
@@ -1,18 +1,7 @@
-import {
-  ContentTag,
-  connect,
-  currentLanguage,
-  provideComponent,
-  useData,
-} from 'scrivito'
+import { ContentTag, provideComponent, useData } from 'scrivito'
 import { DataAttachmentsWidget } from './DataAttachmentsWidgetClass'
-import {
-  dataBinaryToUrl,
-  FullDataBinary,
-  isFullDataBinary,
-} from '../../utils/dataBinaryToUrl'
-import { useEffect, useState } from 'react'
-import prettyBytes from 'pretty-bytes'
+import { FullDataBinary, isFullDataBinary } from '../../utils/dataBinaryToUrl'
+import { Attachment } from '../../Components/Attachment'
 
 provideComponent(DataAttachmentsWidget, ({ widget }) => {
   const dataItemAttribute = useData().dataItemAttribute()
@@ -37,72 +26,6 @@ provideComponent(DataAttachmentsWidget, ({ widget }) => {
     </div>
   )
 })
-
-const Attachment = connect(function Attachment({
-  attachment,
-}: {
-  attachment: FullDataBinary
-}) {
-  const [binaryUrl, setBinaryUrl] = useState<string | undefined>(undefined)
-  const [trigger, setTrigger] = useState<number>(0)
-
-  useEffect(() => {
-    let timeoutId: NodeJS.Timeout
-    dataBinaryToUrl(attachment).then(({ url, maxAge }) => {
-      setBinaryUrl(url)
-      timeoutId = setTimeout(() => setTrigger(Date.now()), maxAge * 1000)
-    })
-
-    return () => {
-      if (timeoutId) clearTimeout(timeoutId)
-    }
-  }, [attachment, trigger])
-
-  return (
-    <a
-      href={binaryUrl}
-      className="box-attachment"
-      title={`Download ${attachment.filename}`}
-    >
-      <div className="box-preview">
-        <BoxPreviewContent binaryUrl={binaryUrl} attachment={attachment} />
-      </div>
-      <div className="box-meta">
-        <span className="box-name">{attachment.filename}</span>
-        <span className="box-size">
-          {prettyBytes(attachment.contentLength, {
-            locale: currentLanguage() ?? 'en',
-          })}
-        </span>
-      </div>
-    </a>
-  )
-})
-
-function BoxPreviewContent({
-  binaryUrl,
-  attachment,
-}: {
-  binaryUrl?: string
-  attachment: FullDataBinary
-}) {
-  if (binaryUrl && attachment.contentType.startsWith('image/')) {
-    return <img src={binaryUrl} alt="" />
-  }
-
-  let iconName = 'bi-file-earmark'
-  const filename = attachment.filename
-  if (filename.endsWith('.pdf')) iconName = 'bi-filetype-pdf'
-  if (filename.endsWith('.docx')) iconName = 'bi-filetype-docx'
-  if (filename.endsWith('.doc')) iconName = 'bi-filetype-doc'
-  if (filename.endsWith('.csv')) iconName = 'bi-filetype-csv'
-  if (filename.endsWith('.json')) iconName = 'bi-filetype-json'
-  if (filename.endsWith('.xml')) iconName = 'bi-filetype-xml'
-  if (filename.endsWith('.txt')) iconName = 'bi-filetype-txt'
-  if (filename.endsWith('.md')) iconName = 'bi-filetype-md'
-
-  return <i className={`bi ${iconName}`}></i>
-}
 
 function isFullBinaryArray(input: unknown): input is FullDataBinary[] {
   return Array.isArray(input) && input.every(isFullDataBinary)

--- a/src/Widgets/DataFormUploadWidget/DataFormUploadWidgetComponent.tsx
+++ b/src/Widgets/DataFormUploadWidget/DataFormUploadWidgetComponent.tsx
@@ -21,12 +21,11 @@ provideComponent(DataFormUploadWidget, ({ widget }) => {
   const onDropAccepted = useCallback(() => setIsTooLarge(false), [])
   const onDropRejected = useCallback(() => setIsTooLarge(true), [])
 
-  const { acceptedFiles, getRootProps, getInputProps, inputRef, isDragActive } =
-    useDropzone({
-      maxSize: MAX_FILE_SIZE,
-      onDropAccepted,
-      onDropRejected,
-    })
+  const { acceptedFiles, getRootProps, getInputProps, inputRef } = useDropzone({
+    maxSize: MAX_FILE_SIZE,
+    onDropAccepted,
+    onDropRejected,
+  })
 
   useEffect(() => {
     if (!inputRef.current) return
@@ -90,7 +89,8 @@ provideComponent(DataFormUploadWidget, ({ widget }) => {
 
       <div
         {...getRootProps({
-          className: `dropzone ${isDragActive ? 'border border-3 rounded-3' : ''}`,
+          className: 'dropzone form-control',
+          style: { cursor: 'pointer' },
         })}
       >
         <input

--- a/src/Widgets/DataFormUploadWidget/DataFormUploadWidgetComponent.tsx
+++ b/src/Widgets/DataFormUploadWidget/DataFormUploadWidgetComponent.tsx
@@ -121,11 +121,20 @@ provideComponent(DataFormUploadWidget, ({ widget }) => {
 })
 
 function getDropMessage(multiple: boolean) {
+  if (multiple) {
+    switch (currentLanguage()) {
+      case 'de':
+        return 'Dateien auswählen oder hierher ziehen.'
+      default:
+        return 'Choose files or drag them here.'
+    }
+  }
+
   switch (currentLanguage()) {
     case 'de':
-      return `Wählen oder legen Sie ${multiple ? 'Dateien' : 'eine Datei'} hier ab.`
+      return 'Datei auswählen oder hierher ziehen.'
     default:
-      return `Choose or drop ${multiple ? 'files' : 'a file'} here.`
+      return 'Choose a file or drag it here.'
   }
 }
 

--- a/src/Widgets/DataFormUploadWidget/DataFormUploadWidgetComponent.tsx
+++ b/src/Widgets/DataFormUploadWidget/DataFormUploadWidgetComponent.tsx
@@ -21,11 +21,12 @@ provideComponent(DataFormUploadWidget, ({ widget }) => {
   const onDropAccepted = useCallback(() => setIsTooLarge(false), [])
   const onDropRejected = useCallback(() => setIsTooLarge(true), [])
 
-  const { acceptedFiles, getRootProps, getInputProps, inputRef } = useDropzone({
-    maxSize: MAX_FILE_SIZE,
-    onDropAccepted,
-    onDropRejected,
-  })
+  const { acceptedFiles, getRootProps, getInputProps, inputRef, isDragActive } =
+    useDropzone({
+      maxSize: MAX_FILE_SIZE,
+      onDropAccepted,
+      onDropRejected,
+    })
 
   useEffect(() => {
     if (!inputRef.current) return
@@ -89,7 +90,7 @@ provideComponent(DataFormUploadWidget, ({ widget }) => {
 
       <div
         {...getRootProps({
-          className: 'dropzone form-control',
+          className: `dropzone form-control${isDragActive ? ' drag-active' : ''}`,
         })}
       >
         <input

--- a/src/Widgets/DataFormUploadWidget/DataFormUploadWidgetComponent.tsx
+++ b/src/Widgets/DataFormUploadWidget/DataFormUploadWidgetComponent.tsx
@@ -90,7 +90,6 @@ provideComponent(DataFormUploadWidget, ({ widget }) => {
       <div
         {...getRootProps({
           className: 'dropzone form-control',
-          style: { cursor: 'pointer' },
         })}
       >
         <input

--- a/src/Widgets/DataFormUploadWidget/DataFormUploadWidgetComponent.tsx
+++ b/src/Widgets/DataFormUploadWidget/DataFormUploadWidgetComponent.tsx
@@ -141,10 +141,10 @@ function getDropMessage(multiple: boolean) {
 function getTooLargeMessage() {
   switch (currentLanguage()) {
     case 'de':
-      return `Eine oder mehrere Dateien sind zu groß. Bitte Dateien bis maximal ${prettyBytes(
+      return `Eine oder mehrere Dateien sind zu groß. Bitte laden Sie Dateien bis maximal ${prettyBytes(
         MAX_FILE_SIZE,
         { locale: 'de' },
-      )} hochladen.`
+      )} hoch.`
     default:
       return `One or more files are too large. Please upload files up to ${prettyBytes(
         MAX_FILE_SIZE,

--- a/src/Widgets/DataFormUploadWidget/DataFormUploadWidgetComponent.tsx
+++ b/src/Widgets/DataFormUploadWidget/DataFormUploadWidgetComponent.tsx
@@ -1,11 +1,37 @@
-import { ContentTag, InPlaceEditingOff, provideComponent } from 'scrivito'
+import {
+  ContentTag,
+  currentLanguage,
+  InPlaceEditingOff,
+  provideComponent,
+} from 'scrivito'
 import { DataFormUploadWidget } from './DataFormUploadWidgetClass'
 import { OverlayTrigger, Popover } from 'react-bootstrap'
+import { useDropzone } from 'react-dropzone'
+import { Attachment } from '../../Components/Attachment'
+import { useEffect } from 'react'
 
 provideComponent(DataFormUploadWidget, ({ widget }) => {
   const id = ['DataFormUploadWidget', widget.id()].join('-')
-
   const attributeName = widget.get('attributeName')
+
+  const { acceptedFiles, getRootProps, getInputProps, inputRef } = useDropzone()
+
+  useEffect(() => {
+    if (!inputRef.current) return
+
+    const dataTransfer = new DataTransfer()
+    acceptedFiles.forEach((file) => dataTransfer.items.add(file))
+
+    inputRef.current.files = dataTransfer.files
+  }, [acceptedFiles, inputRef])
+
+  const attachments = acceptedFiles.map((file) => ({
+    _id: file.name,
+    contentLength: file.size,
+    contentType: file.type,
+    file,
+    filename: file.name,
+  }))
 
   return (
     <div className="mb-3" key={[id, attributeName].join('-')}>
@@ -50,14 +76,33 @@ provideComponent(DataFormUploadWidget, ({ widget }) => {
         </>
       ) : null}
 
-      <input
-        className="form-control"
-        type="file"
-        id={id}
-        multiple={widget.get('multiple')}
-        name={attributeName}
-        required={widget.get('required')}
-      />
+      <div {...getRootProps({ className: 'dropzone' })}>
+        <input
+          {...getInputProps({
+            id,
+            multiple: widget.get('multiple'),
+            name: attributeName,
+            required: widget.get('required'),
+          })}
+        />
+        {getDropMessage(widget.get('multiple'))}
+      </div>
+      <div>
+        <div className="d-flex flex-wrap mt-2 gap-2">
+          {attachments.map((attachment) => (
+            <Attachment attachment={attachment} key={attachment._id} />
+          ))}
+        </div>
+      </div>
     </div>
   )
 })
+
+function getDropMessage(multiple: boolean) {
+  switch (currentLanguage()) {
+    case 'de':
+      return `Wählen oder legen Sie ${multiple ? 'Dateien' : 'eine Datei'} hier ab.`
+    default:
+      return `Choose or drop ${multiple ? 'files' : 'a file'} here.`
+  }
+}

--- a/src/Widgets/DataFormUploadWidget/DataFormUploadWidgetComponent.tsx
+++ b/src/Widgets/DataFormUploadWidget/DataFormUploadWidgetComponent.tsx
@@ -21,11 +21,12 @@ provideComponent(DataFormUploadWidget, ({ widget }) => {
   const onDropAccepted = useCallback(() => setIsTooLarge(false), [])
   const onDropRejected = useCallback(() => setIsTooLarge(true), [])
 
-  const { acceptedFiles, getRootProps, getInputProps, inputRef } = useDropzone({
-    maxSize: MAX_FILE_SIZE,
-    onDropAccepted,
-    onDropRejected,
-  })
+  const { acceptedFiles, getRootProps, getInputProps, inputRef, isDragActive } =
+    useDropzone({
+      maxSize: MAX_FILE_SIZE,
+      onDropAccepted,
+      onDropRejected,
+    })
 
   useEffect(() => {
     if (!inputRef.current) return
@@ -87,7 +88,11 @@ provideComponent(DataFormUploadWidget, ({ widget }) => {
         </>
       ) : null}
 
-      <div {...getRootProps({ className: 'dropzone' })}>
+      <div
+        {...getRootProps({
+          className: `dropzone ${isDragActive ? 'border border-3 rounded-3' : ''}`,
+        })}
+      >
         <input
           {...getInputProps({
             id,

--- a/src/Widgets/DataFormUploadWidget/DataFormUploadWidgetComponent.tsx
+++ b/src/Widgets/DataFormUploadWidget/DataFormUploadWidgetComponent.tsx
@@ -112,7 +112,7 @@ provideComponent(DataFormUploadWidget, ({ widget }) => {
       <div>
         <div className="d-flex flex-wrap mt-2 gap-2">
           {attachments.map((attachment) => (
-            <Attachment attachment={attachment} key={attachment._id} />
+            <Attachment attachment={attachment} key={attachment._id} readonly />
           ))}
         </div>
       </div>

--- a/src/assets/stylesheets/index.scss
+++ b/src/assets/stylesheets/index.scss
@@ -1188,6 +1188,9 @@ section:focus >,
   transition:
     border-color 0.15s ease-in-out,
     box-shadow 0.15s ease-in-out;
+  &.dropzone {
+    cursor: pointer;
+  }
 }
 .form-select {
   font-size: 0.9rem;

--- a/src/assets/stylesheets/index.scss
+++ b/src/assets/stylesheets/index.scss
@@ -1190,9 +1190,6 @@ section:focus >,
     box-shadow 0.15s ease-in-out;
   &.dropzone {
     cursor: pointer;
-    &.drag-active {
-      border: 0.15rem dashed;
-    }
   }
 }
 .form-select {
@@ -1203,6 +1200,7 @@ section:focus >,
   cursor: not-allowed;
 }
 
+.form-control.drag-active,
 .form-control:focus {
   color: #1e2022;
   background-color: #fff;
@@ -1833,6 +1831,7 @@ header .navbar.navbar-expand-lg {
   .box-attachment {
     border: 1px solid #777;
   }
+  .form-control.drag-active,
   .form-control:focus {
     border: 1px solid var(--bs-primary);
   }

--- a/src/assets/stylesheets/index.scss
+++ b/src/assets/stylesheets/index.scss
@@ -1190,6 +1190,9 @@ section:focus >,
     box-shadow 0.15s ease-in-out;
   &.dropzone {
     cursor: pointer;
+    &.drag-active {
+      border: 0.15rem dashed;
+    }
   }
 }
 .form-select {

--- a/src/assets/stylesheets/theme/attachment.scss
+++ b/src/assets/stylesheets/theme/attachment.scss
@@ -6,10 +6,13 @@
   background: white;
   box-shadow: 0 0 3px rgba(0, 0, 0, 0.15);
   border-radius: 5px;
-  cursor: pointer;
 
-  &:hover {
-    background: var(--light-grey);
+  a {
+    cursor: pointer;
+
+    &:hover {
+      background: var(--light-grey);
+    }
   }
 
   .box-preview {

--- a/src/utils/dataBinaryToUrl.ts
+++ b/src/utils/dataBinaryToUrl.ts
@@ -1,3 +1,4 @@
+import { fileToDataUrl } from './fileToDataUrl'
 import { isOptionalString } from './isOptionalString'
 import { pisaDataBinaryToUrl } from './pisaDataBinaryToUrl'
 
@@ -6,6 +7,10 @@ export async function dataBinaryToUrl(
 ): Promise<{ url: string; maxAge: number }> {
   if (isUrlDataBinary(binary)) {
     return { url: binary.url, maxAge: Number.MAX_VALUE }
+  }
+
+  if (binary.file) {
+    return { url: await fileToDataUrl(binary.file), maxAge: Number.MAX_VALUE }
   }
 
   if (binary.dataBase64) {
@@ -36,6 +41,7 @@ export interface FullDataBinary {
   filename: string
   url?: string
   dataBase64?: string
+  file?: File
 }
 
 export function isDataBinary(item: unknown): item is DataBinary {

--- a/src/utils/fileToDataUrl.ts
+++ b/src/utils/fileToDataUrl.ts
@@ -1,8 +1,17 @@
 export async function fileToDataUrl(file: File) {
-  return new Promise<string>((resolve) => {
+  return new Promise<string>((resolve, reject) => {
     const reader = new FileReader()
+
+    reader.onabort = (e) => reject(e)
+    reader.onerror = (e) => reject(e)
     reader.onload = () => {
-      resolve(reader.result as string)
+      const dataUrl = reader.result
+      if (typeof dataUrl !== 'string') {
+        reject(new Error(`FileReader result is not a string: ${dataUrl}`))
+        return
+      }
+
+      resolve(dataUrl)
     }
     reader.readAsDataURL(file)
   })

--- a/src/utils/fileToDataUrl.ts
+++ b/src/utils/fileToDataUrl.ts
@@ -1,0 +1,9 @@
+export async function fileToDataUrl(file: File) {
+  return new Promise<string>((resolve) => {
+    const reader = new FileReader()
+    reader.onload = () => {
+      resolve(reader.result as string)
+    }
+    reader.readAsDataURL(file)
+  })
+}


### PR DESCRIPTION
Allow to drag 'n' drop files on the screen.

Also show a preview of the selected files:

<img width="1624" alt="Screenshot 2024-09-03 at 13 58 38" src="https://github.com/user-attachments/assets/9cf539ae-4ad2-4dbc-87e1-be9c30e3fead">

Last, but not least, limit the files to max. 50 MB:

<img width="1624" alt="Screenshot 2024-09-03 at 13 59 06" src="https://github.com/user-attachments/assets/4f92baf2-0abc-42ca-a74d-cf71b6a5731d">

