### PR TITLE
Protected root

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,4 @@
-import {
-  CurrentPage,
-  NotFoundErrorPage as ScrivitoNotFoundErrorPage,
-} from 'scrivito'
+import { CurrentPage } from 'scrivito'
 import { HelmetProvider, HelmetServerState } from 'react-helmet-async'
 
 import { CurrentPageMetadata } from './Components/CurrentPageMetadata'
@@ -26,9 +23,7 @@ export function App({
           </a>
           <DesignAdjustments>
             <CurrentPage />
-            <ScrivitoNotFoundErrorPage>
-              <NotFoundErrorPage />
-            </ScrivitoNotFoundErrorPage>
+            <NotFoundErrorPage />
           </DesignAdjustments>
           <CurrentPageMetadata />
           <Toasts />

--- a/src/Components/NotFoundErrorPage.tsx
+++ b/src/Components/NotFoundErrorPage.tsx
@@ -2,22 +2,30 @@ import { useEffect } from 'react'
 import {
   connect,
   ContentTag,
+  isUserLoggedIn,
   Obj,
   NotFoundErrorPage as ScrivitoNotFoundErrorPage,
 } from 'scrivito'
+import { Loading } from './Loading'
+import { isNoSitePresent } from '../config/scrivitoSites'
 
 // Make sure, that you have a proxy running for these URLs, otherwise you'll see an endless loop.
 const RELOAD_SUBPATHS = ['/auth']
 
-export const NotFoundErrorPage = connect(function NotFoundErrorPage() {
-  return (
-    <>
-      <ScrivitoNotFoundErrorPage>
-        <NotFound />
-      </ScrivitoNotFoundErrorPage>
-    </>
-  )
-})
+export const NotFoundErrorPage = connect(
+  function NotFoundErrorPage() {
+    if (isUserLoggedIn() && isNoSitePresent()) return <NotFound />
+
+    return (
+      <>
+        <ScrivitoNotFoundErrorPage>
+          <NotFound />
+        </ScrivitoNotFoundErrorPage>
+      </>
+    )
+  },
+  { loading: Loading },
+)
 
 const NotFound = connect(function NotFound() {
   const root = Obj.root()

--- a/src/Components/NotFoundErrorPage.tsx
+++ b/src/Components/NotFoundErrorPage.tsx
@@ -17,11 +17,9 @@ export const NotFoundErrorPage = connect(
     if (isUserLoggedIn() && isNoSitePresent()) return <NotFound />
 
     return (
-      <>
-        <ScrivitoNotFoundErrorPage>
-          <NotFound />
-        </ScrivitoNotFoundErrorPage>
-      </>
+      <ScrivitoNotFoundErrorPage>
+        <NotFound />
+      </ScrivitoNotFoundErrorPage>
     )
   },
   { loading: Loading },

--- a/src/Components/NotFoundErrorPage.tsx
+++ b/src/Components/NotFoundErrorPage.tsx
@@ -14,7 +14,14 @@ const RELOAD_SUBPATHS = ['/auth']
 
 export const NotFoundErrorPage = connect(
   function NotFoundErrorPage() {
-    if (isUserLoggedIn() && isNoSitePresent()) return <NotFound />
+    // TODO: remove window check after #11101 is implemented
+    if (
+      typeof window !== 'undefined' &&
+      isUserLoggedIn() &&
+      isNoSitePresent()
+    ) {
+      return <NotFound />
+    }
 
     return (
       <ScrivitoNotFoundErrorPage>

--- a/src/Components/NotFoundErrorPage.tsx
+++ b/src/Components/NotFoundErrorPage.tsx
@@ -1,10 +1,25 @@
 import { useEffect } from 'react'
-import { connect, ContentTag, Obj } from 'scrivito'
+import {
+  connect,
+  ContentTag,
+  Obj,
+  NotFoundErrorPage as ScrivitoNotFoundErrorPage,
+} from 'scrivito'
 
 // Make sure, that you have a proxy running for these URLs, otherwise you'll see an endless loop.
 const RELOAD_SUBPATHS = ['/auth']
 
 export const NotFoundErrorPage = connect(function NotFoundErrorPage() {
+  return (
+    <>
+      <ScrivitoNotFoundErrorPage>
+        <NotFound />
+      </ScrivitoNotFoundErrorPage>
+    </>
+  )
+})
+
+const NotFound = connect(function NotFound() {
   const root = Obj.root()
 
   // Workaround for issue #10292

--- a/src/config/scrivitoSites.ts
+++ b/src/config/scrivitoSites.ts
@@ -1,4 +1,11 @@
-import { Obj, currentSiteId, getInstanceId, load, navigateTo } from 'scrivito'
+import {
+  Obj,
+  currentSiteId,
+  ensureUserIsLoggedIn,
+  getInstanceId,
+  load,
+  navigateTo,
+} from 'scrivito'
 import { isMultitenancyEnabled } from './scrivitoTenants'
 import { ensureString } from '../utils/ensureString'
 
@@ -72,8 +79,17 @@ function baseUrlsFor(site: Obj) {
   )
 }
 
+export function isNoSitePresent(): boolean {
+  return !appWebsites()?.length
+}
+
 export async function ensureSiteIsPresent() {
   if ((await load(currentSiteId)) === null) {
+    if (await load(isNoSitePresent)) {
+      ensureUserIsLoggedIn()
+      return
+    }
+
     navigateTo(() => {
       const websites = appWebsites() || []
       const preferredLanguageOrder = [...window.navigator.languages, 'en', null]

--- a/src/config/scrivitoSites.ts
+++ b/src/config/scrivitoSites.ts
@@ -86,10 +86,7 @@ export function isNoSitePresent(): boolean {
 export async function ensureSiteIsPresent() {
   if ((await load(currentSiteId)) === null) {
     if (await load(isNoSitePresent)) {
-      // TODO: remove window check after #11101 is implemented
-      if (typeof window !== 'undefined') {
-        ensureUserIsLoggedIn()
-      }
+      ensureUserIsLoggedIn()
       return
     }
 

--- a/src/config/scrivitoSites.ts
+++ b/src/config/scrivitoSites.ts
@@ -86,7 +86,10 @@ export function isNoSitePresent(): boolean {
 export async function ensureSiteIsPresent() {
   if ((await load(currentSiteId)) === null) {
     if (await load(isNoSitePresent)) {
-      ensureUserIsLoggedIn()
+      // TODO: remove window check after #11101 is implemented
+      if (typeof window !== 'undefined') {
+        ensureUserIsLoggedIn()
+      }
       return
     }
 


### PR DESCRIPTION
This PR tries to solve two issue:

* If the tenant in question has no scrivito portal content site show an error
* If the root for the `NotFoundErrorPage` can't be found due to not being logged in - log the user in. This allows for root pages to be protected content.