### PR TITLE
blobToBase64: Bugfix unknown blob type data

### DIFF
--- a/src/utils/blobToBinary.ts
+++ b/src/utils/blobToBinary.ts
@@ -41,7 +41,7 @@ async function blobToBase64(blob: Blob): Promise<string> {
         return
       }
 
-      const dataPrefix = `data:${blob.type};base64,`
+      const dataPrefix = `data:${blob.type || 'application/octet-stream'};base64,`
       if (!dataUrl.startsWith(dataPrefix)) {
         reject(
           new Error(


### PR DESCRIPTION
> Moreover, blob.type is generally reliable only for common file types like images, HTML documents, audio and video. Uncommon file extensions would return an empty string.

Source: https://developer.mozilla.org/en-US/docs/Web/API/Blob/type

Discovered by accidentally picking the a pixelmator file instead of the exported image.