### PR TITLE
Bugfix: Errors during data form submission no longer freeze the app

### DIFF
--- a/src/Data/CurrentUser/errorToast.tsx
+++ b/src/Data/CurrentUser/errorToast.tsx
@@ -3,7 +3,7 @@ import { toast } from 'react-toastify'
 import { ClientError } from 'scrivito'
 
 export function errorToast(title: string, error: unknown): void {
-  console.log('errorToast', title, error)
+  console.error('errorToast', title, error)
   const message =
     error instanceof Error ? error.message : JSON.stringify(error, null, 1)
 

--- a/src/Data/CurrentUser/errorToast.tsx
+++ b/src/Data/CurrentUser/errorToast.tsx
@@ -1,15 +1,15 @@
+import { truncate } from 'lodash-es'
 import { toast } from 'react-toastify'
 import { ClientError } from 'scrivito'
 
 export function errorToast(title: string, error: unknown): void {
+  const message =
+    error instanceof Error ? error.message : JSON.stringify(error, null, 1)
+
   toast.error(
     <>
       <div>{title}</div>
-      <small>
-        {error instanceof Error
-          ? error.message
-          : JSON.stringify(error, null, 1)}
-      </small>
+      <small>{truncate(message, { length: 300, separator: /,? +/ })}</small>
       {error instanceof ClientError ? (
         <pre className="text-small text-muted">
           {JSON.stringify(error.details, null, 1)}

--- a/src/Data/CurrentUser/errorToast.tsx
+++ b/src/Data/CurrentUser/errorToast.tsx
@@ -3,6 +3,7 @@ import { toast } from 'react-toastify'
 import { ClientError } from 'scrivito'
 
 export function errorToast(title: string, error: unknown): void {
+  console.log('errorToast', title, error)
   const message =
     error instanceof Error ? error.message : JSON.stringify(error, null, 1)
 

--- a/src/Data/pisaClient.ts
+++ b/src/Data/pisaClient.ts
@@ -9,7 +9,7 @@ export async function pisaUrl(): Promise<string> {
 
   const url = defaultRoot.get('pisaUrl')
   if (!url) {
-    console.log('Please configure a pisaUrl on the default homepage.')
+    console.error('Please configure a pisaUrl on the default homepage.')
     return never()
   }
 

--- a/src/Widgets/CheckoutButtonWidget/CheckoutButtonWidgetComponent.tsx
+++ b/src/Widgets/CheckoutButtonWidget/CheckoutButtonWidgetComponent.tsx
@@ -14,6 +14,7 @@ import { EditorNote } from '../../Components/EditorNote'
 import { buttonSizeClassName } from '../../utils/buttonSizeClassName'
 import { useState } from 'react'
 import { ModalSpinner } from '../../Components/ModalSpinner'
+import { errorToast } from '../../Data/CurrentUser/errorToast'
 
 provideComponent(CheckoutButtonWidget, ({ widget }) => {
   const [isSubmitting, setIsSubmitting] = useState(false)
@@ -58,13 +59,7 @@ provideComponent(CheckoutButtonWidget, ({ widget }) => {
       navigateTo(result)
       if (successMessage) toast.success(successMessage)
     } catch (error) {
-      if (!(error instanceof Error)) return
-      toast.error(
-        <div>
-          <h6>{error.message}</h6>
-          <p>{errorMessage}</p>
-        </div>,
-      )
+      errorToast(errorMessage, error)
     } finally {
       setIsSubmitting(false)
     }

--- a/src/Widgets/DataFormContainerWidget/DataFormContainerWidgetComponent.tsx
+++ b/src/Widgets/DataFormContainerWidget/DataFormContainerWidgetComponent.tsx
@@ -14,6 +14,7 @@ import { useRef, useState } from 'react'
 import './DataFormContainerWidget.scss'
 import { ModalSpinner } from '../../Components/ModalSpinner'
 import { blobToBinary, DataBinaryUpload } from '../../utils/blobToBinary'
+import { errorToast } from '../../Data/CurrentUser/errorToast'
 
 provideComponent(DataFormContainerWidget, ({ widget }) => {
   const dataScope = useData()
@@ -27,6 +28,8 @@ provideComponent(DataFormContainerWidget, ({ widget }) => {
   const redirectAfterSubmit = widget.get('redirectAfterSubmit')
   const submitOnChange = widget.get('submitOnChange')
   const submittedMessage = widget.get('submittedMessage')
+
+  const errorMessage = getErrorMessage()
 
   return (
     <WidgetTag className="data-form-container-widget">
@@ -68,14 +71,7 @@ provideComponent(DataFormContainerWidget, ({ widget }) => {
         formRef.current.reset()
       }
     } catch (error) {
-      if (!(error instanceof Error)) return
-
-      toast.error(
-        <div>
-          <h6>{error.message}</h6>
-          <p>{getErrorMessage()}</p>
-        </div>,
-      )
+      errorToast(errorMessage, error)
     } finally {
       setIsSubmitting(false)
     }

--- a/src/prerenderContent/reportError.ts
+++ b/src/prerenderContent/reportError.ts
@@ -1,4 +1,4 @@
 export function reportError(message?: string, ...args: unknown[]): void {
   // Report to your external error tracker here, like Honeybadger or Rollbar.
-  console.log(`  ❌ [reportError] ${message}`, ...args)
+  console.error(`  ❌ [reportError] ${message}`, ...args)
 }

--- a/src/utils/provideLocalStorageDataClass.ts
+++ b/src/utils/provideLocalStorageDataClass.ts
@@ -145,7 +145,7 @@ export function provideLocalStorageDataClass(
         localStorage.setItem(initializedKey, initializedValue)
       }
     } catch (e) {
-      console.log('An error occurred during initializing', e)
+      console.error('An error occurred during initializing', e)
     }
   }
 


### PR DESCRIPTION
https://github.com/Scrivito/scrivito-portal-app/pull/589 already provided a bugfix for a specific issue.

The issue could be reproduced, by trying to upload https://drive.google.com/file/d/1t5KUq5yxc9wYqNUI4FDm4yNsr3ukyR0z/view?usp=sharing (this can still be done in the PR). Since prior to https://github.com/Scrivito/scrivito-portal-app/pull/589 the mime type did not match and an error was passed to the `rejected` callback of the promise. This error message was shown in a `toast.error`.

But since the error message was quite long (~3 mb) it crashed the react rendering resulting in an endless "spinner".

This PR prevents the endless "spinner" by limiting the length of string passed to the `toast.error`. You still can't upload the file in this PR, but you will see an error message and be able to continue to use the application.

The bug could potentially also be not regarding the length of the string, but because of the content. It could also be, that this is a bug within React itself. I did not investigate further.