### PR TITLE
Add aspect ratio to video widget

### DIFF
--- a/src/Widgets/VideoWidget/VideoWidget.scss
+++ b/src/Widgets/VideoWidget/VideoWidget.scss
@@ -1,0 +1,27 @@
+.video-widget {
+  object-fit: cover;
+
+  &.aspect-ratio-21to9 {
+    aspect-ratio: calc(21 / 9);
+  }
+
+  &.aspect-ratio-16to9 {
+    aspect-ratio: calc(16 / 9);
+  }
+
+  &.aspect-ratio-4to3 {
+    aspect-ratio: calc(4 / 3);
+  }
+
+  &.aspect-ratio-1to1 {
+    aspect-ratio: calc(1 / 1);
+  }
+
+  &.aspect-ratio-3to4 {
+    aspect-ratio: calc(3 / 4);
+  }
+
+  &.aspect-ratio-9to16 {
+    aspect-ratio: calc(9 / 16);
+  }
+}

--- a/src/Widgets/VideoWidget/VideoWidgetComponent.tsx
+++ b/src/Widgets/VideoWidget/VideoWidgetComponent.tsx
@@ -7,8 +7,10 @@ import {
 } from 'scrivito'
 import { VideoWidget } from './VideoWidgetObjClass'
 import { videoPlaceholder } from './videoPlaceholder'
+import './VideoWidget.scss'
 
 provideComponent(VideoWidget, ({ widget }) => {
+  const aspectRatio = widget.get('aspectRatio') || '16to9'
   const sourceUrl = urlFromBinaryObj(widget.get('source'))
   const posterUrl = urlFromBinaryObj(widget.get('poster'))
 
@@ -21,6 +23,7 @@ provideComponent(VideoWidget, ({ widget }) => {
     <ContentTag
       tag="video"
       key={`${src}${posterUrl}`}
+      className={`video-widget aspect-ratio-${aspectRatio}`}
       src={src}
       content={widget}
       attribute="source"

--- a/src/Widgets/VideoWidget/VideoWidgetEditingConfig.ts
+++ b/src/Widgets/VideoWidget/VideoWidgetEditingConfig.ts
@@ -5,6 +5,18 @@ provideEditingConfig('VideoWidget', {
   title: 'Video',
   thumbnail: Thumbnail,
   attributes: {
+    aspectRatio: {
+      title: 'Aspect ratio',
+      description: 'Default: HD TV (16:9)',
+      values: [
+        { value: '21to9', title: 'CinemaScope (21:9)' },
+        { value: '16to9', title: 'HD TV (16:9)' },
+        { value: '4to3', title: 'Traditional TV (4:3)' },
+        { value: '1to1', title: 'Square (1:1)' },
+        { value: '3to4', title: 'Portrait traditional TV (3:4)' },
+        { value: '9to16', title: 'Portrait HD TV (9:16)' },
+      ],
+    },
     source: {
       title: 'Video',
       description:
@@ -17,7 +29,10 @@ provideEditingConfig('VideoWidget', {
         ' Without an poster image, the browser may show the first frame of the video.',
     },
   },
-  properties: ['source', 'poster'],
+  properties: ['source', 'poster', 'aspectRatio'],
+  initialContent: {
+    aspectRatio: '16to9',
+  },
   validations: [
     [
       'source',

--- a/src/Widgets/VideoWidget/VideoWidgetObjClass.ts
+++ b/src/Widgets/VideoWidget/VideoWidgetObjClass.ts
@@ -4,5 +4,9 @@ export const VideoWidget = provideWidgetClass('VideoWidget', {
   attributes: {
     source: ['reference', { only: ['Video'] }],
     poster: ['reference', { only: ['Image'] }],
+    aspectRatio: [
+      'enum',
+      { values: ['21to9', '16to9', '4to3', '1to1', '3to4', '9to16'] },
+    ],
   },
 })

--- a/src/Widgets/VideoWidget/videoPlaceholder.ts
+++ b/src/Widgets/VideoWidget/videoPlaceholder.ts
@@ -5,7 +5,6 @@ export const videoPlaceholder = {
   backgroundRepeat: 'no-repeat',
   backgroundPosition: 'center',
   boxShadow: '0 0 0 2px #999',
-  height: 90,
   opacity: 0.5,
   width: '100%',
 }


### PR DESCRIPTION
* On par with Youtube and Vimeo widget
* Editors don't have to care about poster image size