### PR TITLE
Show a spinner for not-yet-loaded options

### DIFF
--- a/src/Components/Loading.tsx
+++ b/src/Components/Loading.tsx
@@ -1,15 +1,29 @@
+import { PropsWithChildren } from 'react'
 import { connect, currentLanguage } from 'scrivito'
 
-export const Loading = connect(function Loading() {
+export const Loading = (
+  props: object | PropsWithChildren<{ className?: string }> = {},
+) => <LoadingPlaceholder {...props} />
+
+const LoadingPlaceholder = connect(function LoadingPlaceholder({
+  children,
+  className,
+}: PropsWithChildren<{ className?: string }>) {
+  const classNames = ['loading-placeholder']
+  if (className) classNames.push(className)
+
   const message = getMessage()
+
   return (
     <div
       aria-busy="true"
       aria-valuetext={message}
-      className="loading-placeholder"
+      className={classNames.join(' ')}
       role="progressbar"
       title={message}
-    />
+    >
+      {children}
+    </div>
   )
 })
 

--- a/src/Widgets/DataFormOptionsWidget/DataFormOptionsWidgetComponent.tsx
+++ b/src/Widgets/DataFormOptionsWidget/DataFormOptionsWidgetComponent.tsx
@@ -8,6 +8,7 @@ import {
 } from 'scrivito'
 import { DataFormOptionsWidget } from './DataFormOptionsWidgetClass'
 import { useEnumOptions } from '../../utils/useEnumOptions'
+import { Loading } from '../../Components/Loading'
 
 provideComponent(DataFormOptionsWidget, ({ widget }) => {
   const attributeName = useData().attributeName()
@@ -111,13 +112,9 @@ const Select = connect(
   },
   {
     loading: ({ isRequired }: { isRequired: boolean }) => (
-      <div
-        aria-busy="true"
-        className="w-100 loading-placeholder"
-        role="progressbar"
-      >
+      <Loading className="w-100">
         <select className="form-select" required={isRequired} />
-      </div>
+      </Loading>
     ),
   },
 )

--- a/src/Widgets/DataFormOptionsWidget/DataFormOptionsWidgetComponent.tsx
+++ b/src/Widgets/DataFormOptionsWidget/DataFormOptionsWidgetComponent.tsx
@@ -71,40 +71,53 @@ provideComponent(DataFormOptionsWidget, ({ widget }) => {
   )
 })
 
-const Select = connect(function Select({
-  defaultValue,
-  id,
-  isRequired,
-  name,
-}: {
-  defaultValue: string
-  id: string
-  isRequired: boolean
-  name: string
-}) {
-  const options = useEnumOptions()
+const Select = connect(
+  function Select({
+    defaultValue,
+    id,
+    isRequired,
+    name,
+  }: {
+    defaultValue: string
+    id: string
+    isRequired: boolean
+    name: string
+  }) {
+    const options = useEnumOptions()
 
-  return (
-    <select
-      className="form-select"
-      defaultValue={defaultValue}
-      id={id}
-      name={name}
-      required={isRequired}
-    >
-      {isRequired ? (
-        <option value="" disabled>
-          Select an option
-        </option>
-      ) : (
-        <option value=""></option>
-      )}
+    return (
+      <select
+        className="form-select"
+        defaultValue={defaultValue}
+        id={id}
+        name={name}
+        required={isRequired}
+      >
+        {isRequired ? (
+          <option value="" disabled>
+            Select an option
+          </option>
+        ) : (
+          <option value=""></option>
+        )}
 
-      {options.map(({ value, title }, index) => (
-        <option value={value} key={[id, 'option', value, index].join('-')}>
-          {title}
-        </option>
-      ))}
-    </select>
-  )
-})
+        {options.map(({ value, title }, index) => (
+          <option value={value} key={[id, 'option', value, index].join('-')}>
+            {title}
+          </option>
+        ))}
+      </select>
+    )
+  },
+  {
+    loading: ({ isRequired }: { isRequired: boolean }) => (
+      <div
+        aria-busy="true"
+        className="w-100 loading-placeholder"
+        role="progressbar"
+      >
+        <select className="form-select" required={isRequired} />
+      </div>
+    ),
+  },
+)

--- a/src/Widgets/DataFormOptionsWidget/DataFormOptionsWidgetComponent.tsx
+++ b/src/Widgets/DataFormOptionsWidget/DataFormOptionsWidgetComponent.tsx
@@ -1,5 +1,6 @@
 import { OverlayTrigger, Popover } from 'react-bootstrap'
 import {
+  connect,
   ContentTag,
   InPlaceEditingOff,
   provideComponent,
@@ -15,8 +16,6 @@ provideComponent(DataFormOptionsWidget, ({ widget }) => {
   const value = useData().dataItemAttribute()?.get()
   const defaultValue =
     typeof value === 'string' ? value : widget.get('defaultValue')
-
-  const options = useEnumOptions()
 
   return (
     <div className="mb-3" key={[id, attributeName, defaultValue].join('-')}>
@@ -61,28 +60,51 @@ provideComponent(DataFormOptionsWidget, ({ widget }) => {
       ) : null}
 
       <div>
-        <select
-          className="form-select"
+        <Select
           defaultValue={defaultValue}
           id={id}
+          isRequired={widget.get('required')}
           name={attributeName ?? ''}
-          required={widget.get('required')}
-        >
-          {widget.get('required') ? (
-            <option value="" disabled>
-              Select an option
-            </option>
-          ) : (
-            <option value=""></option>
-          )}
-
-          {options.map(({ value, title }, index) => (
-            <option value={value} key={[id, 'option', value, index].join('-')}>
-              {title}
-            </option>
-          ))}
-        </select>
+        />
       </div>
     </div>
+  )
+})
+
+const Select = connect(function Select({
+  defaultValue,
+  id,
+  isRequired,
+  name,
+}: {
+  defaultValue: string
+  id: string
+  isRequired: boolean
+  name: string
+}) {
+  const options = useEnumOptions()
+
+  return (
+    <select
+      className="form-select"
+      defaultValue={defaultValue}
+      id={id}
+      name={name}
+      required={isRequired}
+    >
+      {isRequired ? (
+        <option value="" disabled>
+          Select an option
+        </option>
+      ) : (
+        <option value=""></option>
+      )}
+
+      {options.map(({ value, title }, index) => (
+        <option value={value} key={[id, 'option', value, index].join('-')}>
+          {title}
+        </option>
+      ))}
+    </select>
   )
 })


### PR DESCRIPTION
I made sure a form with a required enum can't be sent.

There are two other widgets using `useEnumOptions` (DataIconWidget and DataLabelWidget), but every instance of these is used inside data or detail pages, so their loading behavior already matches how the rest of the page behaves.

<img width="847" alt="image" src="https://github.com/user-attachments/assets/4319297f-1c06-4470-90fc-f4652efc3b1f">
