### PR TITLE
Accessibility: Add more "alt" tags + eslint rule

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -16,6 +16,11 @@
   "settings": {
     "react": {
       "version": "detect"
+    },
+    "jsx-a11y": {
+      "components": {
+        "ImageTag": "img"
+      }
     }
   },
   "rules": {

--- a/src/Components/ScrivitoExtensions/SocialCardsTab.tsx
+++ b/src/Components/ScrivitoExtensions/SocialCardsTab.tsx
@@ -55,7 +55,12 @@ const TwitterInput = connect(({ obj }: { obj: Obj }) => (
     <div className="scrivito_detail_label">
       <span>Image</span>
     </div>
-    <ImageTag content={obj} attribute="tcImage" className="social_card_img" />
+    <ImageTag
+      alt=""
+      attribute="tcImage"
+      className="social_card_img"
+      content={obj}
+    />
     <div className="scrivito_notice_body">Add or replace the image here.</div>
     <ContentProperty content={obj} attribute="tcTitle" title="Title" />
     <ContentProperty
@@ -75,7 +80,12 @@ const FacebookInput = connect(({ obj }) => (
     <div className="scrivito_detail_label">
       <span>Image</span>
     </div>
-    <ImageTag content={obj} attribute="ogImage" className="social_card_img" />
+    <ImageTag
+      alt=""
+      attribute="ogImage"
+      className="social_card_img"
+      content={obj}
+    />
     <div className="scrivito_notice_body">Add or replace the image here.</div>
     <ContentProperty
       content={obj}

--- a/src/Objs/Product/ProductComponent.tsx
+++ b/src/Objs/Product/ProductComponent.tsx
@@ -15,7 +15,6 @@ import {
 } from '../../Widgets/ProductParameterWidget/ProductParameterWidgetClass'
 import { ProductPreview } from './ProductPreviewComponent'
 import { addToCart, isInCart, removeFromCart } from '../../Data/CartItem/Cart'
-import { alternativeTextForObj } from '../../utils/alternativeTextForObj'
 
 provideComponent(Product, ({ page }) => {
   const plainParameters = page
@@ -34,7 +33,7 @@ provideComponent(Product, ({ page }) => {
                   content={page}
                   attribute="image"
                   className="img-background"
-                  alt={alternativeTextForObj(page.get('image'))}
+                  alt=""
                 />
               </div>
             </div>

--- a/src/Objs/Product/ProductComponent.tsx
+++ b/src/Objs/Product/ProductComponent.tsx
@@ -15,6 +15,7 @@ import {
 } from '../../Widgets/ProductParameterWidget/ProductParameterWidgetClass'
 import { ProductPreview } from './ProductPreviewComponent'
 import { addToCart, isInCart, removeFromCart } from '../../Data/CartItem/Cart'
+import { alternativeTextForObj } from '../../utils/alternativeTextForObj'
 
 provideComponent(Product, ({ page }) => {
   const plainParameters = page
@@ -33,6 +34,7 @@ provideComponent(Product, ({ page }) => {
                   content={page}
                   attribute="image"
                   className="img-background"
+                  alt={alternativeTextForObj(page.get('image'))}
                 />
               </div>
             </div>

--- a/src/Widgets/SearchResultsWidget/SearchResultsWidgetComponent.tsx
+++ b/src/Widgets/SearchResultsWidget/SearchResultsWidgetComponent.tsx
@@ -41,9 +41,10 @@ provideComponent(SearchResultsWidget, ({ widget }) => {
     <InPlaceEditingOff>
       <section className="bg-primary py-5">
         <ImageTag
-          content={widget}
+          alt=""
           attribute="topBannerBackground"
           className="img-background"
+          content={widget}
         />
         <div className="container">
           <form


### PR DESCRIPTION
With this all `ImageTag` in our code-base should have an alt tag now.

Discovered with:

```
npx @axe-core/cli https://scrivito-portal-app.pages.dev/en/plug-in-nozzle-0-3mm-6eff94f91196a7d4 --tags wcag2a --load-delay=500 --exit
```

The other complained is addressed in https://github.com/Scrivito/scrivito-portal-app/pull/629.