### PR TITLE
Accessibility: LanguageSwitcher - Add an aria-label

### DIFF
--- a/src/Widgets/TopNavigationWidget/SubComponents/LanguageSwitch.tsx
+++ b/src/Widgets/TopNavigationWidget/SubComponents/LanguageSwitch.tsx
@@ -65,7 +65,7 @@ const LanguageLabel = connect(function LanguageLabel({
   root: HomepageInstance
 }) {
   return (
-    <>
+    <span aria-label={displayName(root.language())}>
       <ImageTag
         alt=""
         content={root}
@@ -73,7 +73,7 @@ const LanguageLabel = connect(function LanguageLabel({
         className="img-flag"
       />
       <span className={className}>{displayName(root.language())}</span>
-    </>
+    </span>
   )
 })
 


### PR DESCRIPTION
Without this, a11y tools will complain that "Ensures links have discernible text." because no text is visible inside the link.

Discovered with:

```
npx @axe-core/cli https://scrivito-portal-app.pages.dev/en --tags wcag2a --load-delay=500 --exit
```