### PR TITLE
provideLocalStorageDataClass: Separate localstorage by tenantId

### DIFF
--- a/src/Data/CallbackRequest/LocalStorage/localStorageCallbackRequestDataClass.ts
+++ b/src/Data/CallbackRequest/LocalStorage/localStorageCallbackRequestDataClass.ts
@@ -1,5 +1,5 @@
 import { currentLanguage, load } from 'scrivito'
-import { provideLocalStorageDataClass } from '../../../utils/provideLocalStorageDataClass'
+import { provideLocalStorageDataClass } from '../../provideLocalStorageDataClass'
 import { DataClassSchema } from '../../types'
 
 async function attributes(): Promise<DataClassSchema> {

--- a/src/Data/CartItem/CartItemDataClass.ts
+++ b/src/Data/CartItem/CartItemDataClass.ts
@@ -1,3 +1,3 @@
-import { provideLocalStorageDataClass } from '../../utils/provideLocalStorageDataClass'
+import { provideLocalStorageDataClass } from '../provideLocalStorageDataClass'
 
 export const CartItem = provideLocalStorageDataClass('CartItem')

--- a/src/Data/Contract/LocalStorage/localStorageContractDataClass.ts
+++ b/src/Data/Contract/LocalStorage/localStorageContractDataClass.ts
@@ -1,5 +1,5 @@
 import { currentLanguage, load } from 'scrivito'
-import { provideLocalStorageDataClass } from '../../../utils/provideLocalStorageDataClass'
+import { provideLocalStorageDataClass } from '../../provideLocalStorageDataClass'
 import { DataClassSchema } from '../../types'
 
 async function attributes(): Promise<DataClassSchema> {

--- a/src/Data/ContractDocument/LocalStorage/localStorageContractDocumentDataClass.ts
+++ b/src/Data/ContractDocument/LocalStorage/localStorageContractDocumentDataClass.ts
@@ -1,4 +1,4 @@
-import { provideLocalStorageDataClass } from '../../../utils/provideLocalStorageDataClass'
+import { provideLocalStorageDataClass } from '../../provideLocalStorageDataClass'
 import { DataClassAttributes } from '../../types'
 
 const attributes: DataClassAttributes = {}

--- a/src/Data/Document/LocalStorage/localStorageDocumentDataClass.ts
+++ b/src/Data/Document/LocalStorage/localStorageDocumentDataClass.ts
@@ -1,4 +1,4 @@
-import { provideLocalStorageDataClass } from '../../../utils/provideLocalStorageDataClass'
+import { provideLocalStorageDataClass } from '../../provideLocalStorageDataClass'
 import penImage from './FakeBinaries/pen.jpg'
 import kmkPdf from './FakeBinaries/KMK-overview_(Karlsruhe_Exhibition_Centre).pdf'
 import orderPdf from './FakeBinaries/ORDER.pdf'

--- a/src/Data/Event/LocalStorage/localStorageEventDataClass.ts
+++ b/src/Data/Event/LocalStorage/localStorageEventDataClass.ts
@@ -1,5 +1,5 @@
 import { currentLanguage, load } from 'scrivito'
-import { provideLocalStorageDataClass } from '../../../utils/provideLocalStorageDataClass'
+import { provideLocalStorageDataClass } from '../../provideLocalStorageDataClass'
 import { DataClassSchema } from '../../types'
 import spiderImage from './FakeBinaries/Schulung_Spider_30.png'
 import roadshowImage from './FakeBinaries/TYNACOON_Roadshow.jpg'

--- a/src/Data/EventDocument/LocalStorage/localStorageEventDocumentDataClass.ts
+++ b/src/Data/EventDocument/LocalStorage/localStorageEventDocumentDataClass.ts
@@ -1,4 +1,4 @@
-import { provideLocalStorageDataClass } from '../../../utils/provideLocalStorageDataClass'
+import { provideLocalStorageDataClass } from '../../provideLocalStorageDataClass'
 import { DataClassAttributes } from '../../types'
 
 const attributes: DataClassAttributes = {}

--- a/src/Data/EventRegistration/LocalStorage/localStorageEventRegistrationDataClass.ts
+++ b/src/Data/EventRegistration/LocalStorage/localStorageEventRegistrationDataClass.ts
@@ -1,4 +1,4 @@
-import { provideLocalStorageDataClass } from '../../../utils/provideLocalStorageDataClass'
+import { provideLocalStorageDataClass } from '../../provideLocalStorageDataClass'
 import { DataClassAttributes } from '../../types'
 
 const attributes: DataClassAttributes = {}

--- a/src/Data/Gdpr/LocalStorage/localStorageGdprDataClass.ts
+++ b/src/Data/Gdpr/LocalStorage/localStorageGdprDataClass.ts
@@ -1,5 +1,5 @@
 import { currentLanguage, load } from 'scrivito'
-import { provideLocalStorageDataClass } from '../../../utils/provideLocalStorageDataClass'
+import { provideLocalStorageDataClass } from '../../provideLocalStorageDataClass'
 import { DataClassSchema } from '../../types'
 
 async function attributes(): Promise<DataClassSchema> {

--- a/src/Data/Message/LocalStorage/localStorageMessageDataClass.ts
+++ b/src/Data/Message/LocalStorage/localStorageMessageDataClass.ts
@@ -1,5 +1,5 @@
 import { currentLanguage, load } from 'scrivito'
-import { provideLocalStorageDataClass } from '../../../utils/provideLocalStorageDataClass'
+import { provideLocalStorageDataClass } from '../../provideLocalStorageDataClass'
 import { DataClassSchema } from '../../types'
 
 async function attributes(): Promise<DataClassSchema> {

--- a/src/Data/Opportunity/LocalStorage/localStorageOpportunityDataClass.ts
+++ b/src/Data/Opportunity/LocalStorage/localStorageOpportunityDataClass.ts
@@ -1,5 +1,5 @@
 import { currentLanguage, load } from 'scrivito'
-import { provideLocalStorageDataClass } from '../../../utils/provideLocalStorageDataClass'
+import { provideLocalStorageDataClass } from '../../provideLocalStorageDataClass'
 import { DataClassSchema } from '../../types'
 
 async function attributes(): Promise<DataClassSchema> {

--- a/src/Data/Order/LocalStorage/localStorageOrderDataClass.ts
+++ b/src/Data/Order/LocalStorage/localStorageOrderDataClass.ts
@@ -1,5 +1,5 @@
 import { currentLanguage, load } from 'scrivito'
-import { provideLocalStorageDataClass } from '../../../utils/provideLocalStorageDataClass'
+import { provideLocalStorageDataClass } from '../../provideLocalStorageDataClass'
 import { DataClassSchema } from '../../types'
 
 async function attributes(): Promise<DataClassSchema> {

--- a/src/Data/OrderDocument/LocalStorage/localStorageOrderDocumentDataClass.ts
+++ b/src/Data/OrderDocument/LocalStorage/localStorageOrderDocumentDataClass.ts
@@ -1,4 +1,4 @@
-import { provideLocalStorageDataClass } from '../../../utils/provideLocalStorageDataClass'
+import { provideLocalStorageDataClass } from '../../provideLocalStorageDataClass'
 import { DataClassAttributes } from '../../types'
 
 const attributes: DataClassAttributes = {}

--- a/src/Data/OrderRequest/LocalStorage/localStorageOrderRequestDataClass.ts
+++ b/src/Data/OrderRequest/LocalStorage/localStorageOrderRequestDataClass.ts
@@ -1,4 +1,4 @@
-import { provideLocalStorageDataClass } from '../../../utils/provideLocalStorageDataClass'
+import { provideLocalStorageDataClass } from '../../provideLocalStorageDataClass'
 import { DataClassAttributes } from '../../types'
 
 const attributes: DataClassAttributes = {}

--- a/src/Data/Quote/LocalStorage/localStorageQuoteDataClass.ts
+++ b/src/Data/Quote/LocalStorage/localStorageQuoteDataClass.ts
@@ -1,5 +1,5 @@
 import { currentLanguage, load } from 'scrivito'
-import { provideLocalStorageDataClass } from '../../../utils/provideLocalStorageDataClass'
+import { provideLocalStorageDataClass } from '../../provideLocalStorageDataClass'
 import { DataClassSchema } from '../../types'
 
 async function attributes(): Promise<DataClassSchema> {

--- a/src/Data/QuoteDocument/LocalStorage/localStorageQuoteDocumentDataClass.ts
+++ b/src/Data/QuoteDocument/LocalStorage/localStorageQuoteDocumentDataClass.ts
@@ -1,4 +1,4 @@
-import { provideLocalStorageDataClass } from '../../../utils/provideLocalStorageDataClass'
+import { provideLocalStorageDataClass } from '../../provideLocalStorageDataClass'
 import { DataClassAttributes } from '../../types'
 
 const attributes: DataClassAttributes = {}

--- a/src/Data/ServiceObject/LocalStorage/localStorageServiceObjectDataClass.ts
+++ b/src/Data/ServiceObject/LocalStorage/localStorageServiceObjectDataClass.ts
@@ -1,5 +1,5 @@
 import { currentLanguage, load } from 'scrivito'
-import { provideLocalStorageDataClass } from '../../../utils/provideLocalStorageDataClass'
+import { provideLocalStorageDataClass } from '../../provideLocalStorageDataClass'
 import { DataClassSchema } from '../../types'
 import machineImage from './FakeBinaries/machine.jpg'
 import pumpImage from './FakeBinaries/pump.jpg'

--- a/src/Data/ServiceObjectDocument/LocalStorage/localStorageServiceObjectDocumentDataClass.ts
+++ b/src/Data/ServiceObjectDocument/LocalStorage/localStorageServiceObjectDocumentDataClass.ts
@@ -1,4 +1,4 @@
-import { provideLocalStorageDataClass } from '../../../utils/provideLocalStorageDataClass'
+import { provideLocalStorageDataClass } from '../../provideLocalStorageDataClass'
 import { DataClassAttributes } from '../../types'
 
 const attributes: DataClassAttributes = {}

--- a/src/Data/Ticket/LocalStorage/localStorageTicketDataClass.ts
+++ b/src/Data/Ticket/LocalStorage/localStorageTicketDataClass.ts
@@ -1,5 +1,5 @@
 import { currentLanguage, load } from 'scrivito'
-import { provideLocalStorageDataClass } from '../../../utils/provideLocalStorageDataClass'
+import { provideLocalStorageDataClass } from '../../provideLocalStorageDataClass'
 import { pseudoRandom32CharHex } from '../../../utils/pseudoRandom32CharHex'
 import { DataClassSchema } from '../../types'
 

--- a/src/Data/User/LocalStorage/localStorageUserDataClass.ts
+++ b/src/Data/User/LocalStorage/localStorageUserDataClass.ts
@@ -1,4 +1,4 @@
-import { provideLocalStorageDataClass } from '../../../utils/provideLocalStorageDataClass'
+import { provideLocalStorageDataClass } from '../../provideLocalStorageDataClass'
 import richterImage from './FakeBinaries/richter.jpg'
 import braschauImage from './FakeBinaries/braschau.jpg'
 import fuchsImage from './FakeBinaries/fuchs.jpg'

--- a/src/Data/provideLocalStorageDataClass.ts
+++ b/src/Data/provideLocalStorageDataClass.ts
@@ -1,8 +1,8 @@
 import { provideDataClass } from 'scrivito'
-import { pseudoRandom32CharHex } from './pseudoRandom32CharHex'
+import { pseudoRandom32CharHex } from '../utils/pseudoRandom32CharHex'
 import { orderBy } from 'lodash-es'
-import { ensureString } from './ensureString'
-import { DataClassAttributes } from '../Data/types'
+import { ensureString } from '../utils/ensureString'
+import { DataClassAttributes } from './types'
 import { scrivitoTenantId } from '../config/scrivitoTenants'
 
 interface DataItem {


### PR DESCRIPTION
This way - in a multi tenancy setup - the data from one tenant does _not_ show up in another tenant.

Please note, that all existing localstorage data will no longer be readable.