### PR TITLE
siteForUrl: Bugfix - ignore query and search from input URL

### DIFF
--- a/src/config/scrivitoSites.ts
+++ b/src/config/scrivitoSites.ts
@@ -52,7 +52,7 @@ export function siteForUrl(
 
 function languageForUrl(url: string) {
   const regex = new RegExp(
-    `^${getBaseAppUrl()}\\/(?<lang>[a-z]{2}(-[A-Z]{2})?)([?/]|$)`,
+    `^${getBaseAppUrl()}\\/(?<lang>[a-z]{2}(-[A-Z]{2})?)([?/#]|$)`,
   )
   return regex.exec(url)?.groups?.lang
 }


### PR DESCRIPTION
Otherwise hash links like https://scrivito-portal-app.pages.dev/en#ecoline will not work. With this PR it works (see https://siteforurl-ignores-hash-and.scrivito-portal-app.pages.dev/en#ecoline).