### PR TITLE
Remove type workaround for local storage data

### DIFF
--- a/src/Data/Contract/LocalStorage/localStorageContractDataClass.ts
+++ b/src/Data/Contract/LocalStorage/localStorageContractDataClass.ts
@@ -1,8 +1,7 @@
 import { currentLanguage, load } from 'scrivito'
 import { provideLocalStorageDataClass } from '../../provideLocalStorageDataClass'
-import { ReadonlyDataClassSchema } from '../../types'
 
-async function attributes(): Promise<ReadonlyDataClassSchema> {
+async function attributes() {
   const lang = await load(currentLanguage)
 
   const category = [

--- a/src/Data/Document/LocalStorage/localStorageDocumentDataClass.ts
+++ b/src/Data/Document/LocalStorage/localStorageDocumentDataClass.ts
@@ -2,10 +2,9 @@ import { provideLocalStorageDataClass } from '../../provideLocalStorageDataClass
 import penImage from './FakeBinaries/pen.jpg'
 import kmkPdf from './FakeBinaries/KMK-overview_(Karlsruhe_Exhibition_Centre).pdf'
 import orderPdf from './FakeBinaries/ORDER.pdf'
-import { ReadonlyDataClassSchema } from '../../types'
 import { currentLanguage, load } from 'scrivito'
 
-async function attributes(): Promise<ReadonlyDataClassSchema> {
+async function attributes() {
   const lang = await load(currentLanguage)
 
   const language = [

--- a/src/Data/Event/LocalStorage/localStorageEventDataClass.ts
+++ b/src/Data/Event/LocalStorage/localStorageEventDataClass.ts
@@ -1,10 +1,9 @@
 import { currentLanguage, load } from 'scrivito'
 import { provideLocalStorageDataClass } from '../../provideLocalStorageDataClass'
-import { ReadonlyDataClassSchema } from '../../types'
 import spiderImage from './FakeBinaries/Schulung_Spider_30.png'
 import roadshowImage from './FakeBinaries/TYNACOON_Roadshow.jpg'
 
-async function attributes(): Promise<ReadonlyDataClassSchema> {
+async function attributes() {
   const lang = await load(currentLanguage)
 
   const language = [

--- a/src/Data/Order/LocalStorage/localStorageOrderDataClass.ts
+++ b/src/Data/Order/LocalStorage/localStorageOrderDataClass.ts
@@ -1,8 +1,7 @@
 import { currentLanguage, load } from 'scrivito'
 import { provideLocalStorageDataClass } from '../../provideLocalStorageDataClass'
-import { ReadonlyDataClassSchema } from '../../types'
 
-async function attributes(): Promise<ReadonlyDataClassSchema> {
+async function attributes() {
   const lang = await load(currentLanguage)
 
   const mainStatus = [

--- a/src/Data/Quote/LocalStorage/localStorageQuoteDataClass.ts
+++ b/src/Data/Quote/LocalStorage/localStorageQuoteDataClass.ts
@@ -1,8 +1,7 @@
 import { currentLanguage, load } from 'scrivito'
 import { provideLocalStorageDataClass } from '../../provideLocalStorageDataClass'
-import { ReadonlyDataClassSchema } from '../../types'
 
-async function attributes(): Promise<ReadonlyDataClassSchema> {
+async function attributes() {
   const lang = await load(currentLanguage)
 
   const mainStatus = [

--- a/src/Data/ServiceObject/LocalStorage/localStorageServiceObjectDataClass.ts
+++ b/src/Data/ServiceObject/LocalStorage/localStorageServiceObjectDataClass.ts
@@ -1,10 +1,9 @@
 import { currentLanguage, load } from 'scrivito'
 import { provideLocalStorageDataClass } from '../../provideLocalStorageDataClass'
-import { ReadonlyDataClassSchema } from '../../types'
 import machineImage from './FakeBinaries/machine.jpg'
 import pumpImage from './FakeBinaries/pump.jpg'
 
-async function attributes(): Promise<ReadonlyDataClassSchema> {
+async function attributes() {
   const lang = await load(currentLanguage)
 
   const category = [

--- a/src/Data/Ticket/LocalStorage/localStorageTicketDataClass.ts
+++ b/src/Data/Ticket/LocalStorage/localStorageTicketDataClass.ts
@@ -1,9 +1,8 @@
 import { currentLanguage, load } from 'scrivito'
 import { provideLocalStorageDataClass } from '../../provideLocalStorageDataClass'
 import { pseudoRandom32CharHex } from '../../../utils/pseudoRandom32CharHex'
-import { ReadonlyDataClassSchema } from '../../types'
 
-async function attributes(): Promise<ReadonlyDataClassSchema> {
+async function attributes() {
   const lang = await load(currentLanguage)
 
   const status = [

--- a/src/Data/User/LocalStorage/localStorageUserDataClass.ts
+++ b/src/Data/User/LocalStorage/localStorageUserDataClass.ts
@@ -4,10 +4,9 @@ import braschauImage from './FakeBinaries/braschau.jpg'
 import fuchsImage from './FakeBinaries/fuchs.jpg'
 import bachImage from './FakeBinaries/bach.jpg'
 import { postProcessUserData } from '../UserDataClass'
-import { ReadonlyDataClassSchema } from '../../types'
 import { currentLanguage, load } from 'scrivito'
 
-async function attributes(): Promise<ReadonlyDataClassSchema> {
+async function attributes() {
   const lang = await load(currentLanguage)
 
   const salutation = [

--- a/src/Data/types.ts
+++ b/src/Data/types.ts
@@ -23,9 +23,3 @@ export type DataClassAttributes = Readonly<Params['attributes']>
 
 type ExtractDataClassSchema<T> = T extends Promise<infer U> ? U : never
 export type DataClassSchema = ExtractDataClassSchema<DataClassAttributes>
-
-// TODO: Remove when #11321 is resolved
-type ExtractReadonlyDataClassSchema<T> =
-  T extends Promise<infer U> ? { [K in keyof U]: Readonly<U[K]> } : never
-export type ReadonlyDataClassSchema =
-  ExtractReadonlyDataClassSchema<DataClassAttributes>


### PR DESCRIPTION
This type was used module-internal only anyway.
The typed return values could be reintroduced with a publicly exported type later on.

The PR is a suggestion only. Feel free to stick with the workaround and close it.