### PR TITLE
User: Ignore salutation of current user

### DIFF
--- a/src/Data/User/UserDataClass.ts
+++ b/src/Data/User/UserDataClass.ts
@@ -24,6 +24,6 @@ export async function postProcessUserData(
     givenName: await load(() => CurrentUser.get('givenName')),
     image: { url: await load(() => CurrentUser.get('picture')) },
     name: await load(() => CurrentUser.get('name')),
-    salutation: await load(() => CurrentUser.get('salutation')),
+    // Ignoring `salutation`, since neoletter's attribute is a plain string (e.g. `Frau` or `Herr`), whereas PisaSales responds with an enum value such as `F` or `M`.
   }
 }


### PR DESCRIPTION
Prior to this change the situation was this:
* Neoletter profile service allows to set an arbitrary `salutation` - any string such as "Ms.", "Mr.", "Frau", "Herr" or even other strings such as "Master of the universe" can be set by the user itself.
* PisaSales uses an enum value for salutation, e.g. "F" or "M".

If we merge the salutation of neoletter's my profile service with the salutation of the current user in PisaSales "users" Scrivito will rightfully complain with:

```
Expected attribute "salutation" of data class "User" to be one of ["M","F","ME","FE","MS","FS","MSP","FSP","MF","FF"], but got "Herr"
```

To avoid this situation, this PR no longer merges the salutation of the current user into the user, but leaves the "salutation" data to the value as provided by PisaSales.