### PR TITLE
Filter `parentId` from service object attributes

### DIFF
--- a/src/Data/ServiceObject/LocalStorage/localStorageServiceObjectDataClass.ts
+++ b/src/Data/ServiceObject/LocalStorage/localStorageServiceObjectDataClass.ts
@@ -720,16 +720,17 @@ async function attributes(): Promise<ReadonlyDataClassSchema> {
       { title: lang === 'de' ? 'Modellnummer' : 'Model number' },
     ],
     number: ['string', { title: lang === 'de' ? 'Nummer' : 'Number' }],
-    parentId: [
-      'reference',
-      {
-        title:
-          lang === 'de'
-            ? 'Übergeordnetes Serviceobjekt'
-            : 'Parent service object',
-        to: 'ServiceObject',
-      },
-    ],
+    // TODO: Remove workaround for #11367 once available
+    // parentId: [
+    //   'reference',
+    //   {
+    //     title:
+    //       lang === 'de'
+    //         ? 'Übergeordnetes Serviceobjekt'
+    //         : 'Parent service object',
+    //     to: 'ServiceObject',
+    //   },
+    // ],
     product: [
       'string',
       { title: lang === 'de' ? 'Produktname' : 'Product name' },

--- a/src/Data/ServiceObject/Pisa/pisaServiceObjectDataClass.ts
+++ b/src/Data/ServiceObject/Pisa/pisaServiceObjectDataClass.ts
@@ -1,8 +1,10 @@
 import { provideDataClass } from 'scrivito'
 import { pisaConfig } from '../../pisaClient'
+import { fetchAttributes } from '../../fetchAttributes'
 
 export function pisaServiceObjectDataClass() {
   return provideDataClass('ServiceObject', {
+    attributes: fetchAttributes('service-object', ['parentId']), // TODO: Remove workaround for #11367 once available
     restApi: pisaConfig('service-object'),
   })
 }

--- a/src/Data/fetchAttributes.ts
+++ b/src/Data/fetchAttributes.ts
@@ -1,14 +1,22 @@
 import { pisaClient } from './pisaClient'
 import { DataClassSchema } from './types'
 
-/** Fetches the schema for `subPath`. */
+/**
+ * Fetches the schema for `subPath`.
+ * Allows optionally to `ignoreAttributes`.
+ * */
 export async function fetchAttributes(
   subPath: string,
+  ignoreAttributes: string[] = [],
 ): Promise<DataClassSchema> {
   const client = await pisaClient(subPath)
   const schema = (await client.get('schema')) as {
     attributes: DataClassSchema
   }
 
-  return schema.attributes
+  return Object.fromEntries(
+    Object.entries(schema.attributes).filter(
+      ([attributeName]) => !ignoreAttributes.includes(attributeName),
+    ),
+  )
 }

--- a/src/Data/provideLocalStorageDataClass.ts
+++ b/src/Data/provideLocalStorageDataClass.ts
@@ -226,7 +226,9 @@ function compare({
 
   const eq =
     itemValue === filterValue ||
+    (filterValue === null && itemValue === undefined) ||
     (filterValue === 'null' && itemValue === null) ||
+    (filterValue === 'null' && itemValue === undefined) ||
     (filterValue === 'true' && itemValue === true) ||
     (filterValue === 'false' && itemValue === false)
 


### PR DESCRIPTION
This allows to set arbitrary values for parentId, e.g. the string `'null'`. With this PisaSales will only return service objects, that don't have a parent object. See #11367 for more details.

Needs content: https://edit.scrivito.com/d0a154d76edf2a7bd991fc658e700a1d~https://filter-parentid.scrivito-portal-app.pages.dev/en/equipment?_scrivito_workspace_id=q85ff08c54c0e147&_scrivito_display_mode=view