### PR TITLE
Safari design glitch fix

### DIFF
--- a/src/assets/stylesheets/index.scss
+++ b/src/assets/stylesheets/index.scss
@@ -1341,6 +1341,7 @@ section:focus >,
   max-height: 81px;
   min-height: 37px;
   object-fit: contain;
+  width: min-content;
 }
 .navbar {
   padding: 0;


### PR DESCRIPTION
How to reproduce (all in Safari):

* Visit https://scrivito-portal-app.pages.dev/de
* Adjust the window width

Expected: The logo always uses the correct amount of space (especially the width).

Actual: Sometimes the white area around the logo would be much larger then expected.


Now repeat with https://bugfix-safari-navigation-gli.scrivito-portal-app.pages.dev/de to see if this PR fixes it (at least for me it does).


Kudos to @agessler for finding the fix!