### PR TITLE
NotFoundErrorPage: Added get started button

### DIFF
--- a/src/Components/NotFoundErrorPage.tsx
+++ b/src/Components/NotFoundErrorPage.tsx
@@ -2,6 +2,7 @@ import { useEffect } from 'react'
 import {
   connect,
   ContentTag,
+  isEditorLoggedIn,
   isUserLoggedIn,
   Obj,
   NotFoundErrorPage as ScrivitoNotFoundErrorPage,
@@ -42,7 +43,16 @@ const NotFound = connect(function NotFound() {
   }, [])
 
   if (!root) {
-    return <div>Page not found.</div>
+    return (
+      <main id="main">
+        <section className="py-1">
+          <div className="container">
+            <div>Page not found.</div>
+            <GetStartedButton />
+          </div>
+        </section>
+      </main>
+    )
   }
 
   // TODO: Consolidate with HomepageLayoutComponent
@@ -64,3 +74,20 @@ const NotFound = connect(function NotFound() {
     </>
   )
 })
+
+const GetStartedButton = connect(
+  function GetStartedButton() {
+    if (isEditorLoggedIn()) return null
+    if (Obj.onAllSites().all().count() > 0) return null
+
+    return (
+      <a
+        className="btn btn-primary"
+        href={`https://edit.scrivito.com/${location.href}`}
+      >
+        Get started with your CMS
+      </a>
+    )
+  },
+  { loading: Loading },
+)


### PR DESCRIPTION
Adds a "Get started with your CMS" button if the given tenant is empty. A visit to that link with automatically initialize the content for the tenant.

<img width="1624" alt="Screenshot 2024-11-25 at 14 50 10" src="https://github.com/user-attachments/assets/689e5f85-6c73-4718-ba47-3dd6757c7401">
