### PR TITLE
ServiceObject: Bugfix fetching attributes

### DIFF
--- a/src/Data/ServiceObject/Pisa/pisaServiceObjectDataClass.ts
+++ b/src/Data/ServiceObject/Pisa/pisaServiceObjectDataClass.ts
@@ -4,7 +4,7 @@ import { fetchAttributes } from '../../fetchAttributes'
 
 export function pisaServiceObjectDataClass() {
   return provideDataClass('ServiceObject', {
-    attributes: fetchAttributes('service-object', ['parentId']), // TODO: Remove workaround for #11367 once available
+    attributes: () => fetchAttributes('service-object', ['parentId']), // TODO: Remove workaround for #11367 once available
     restApi: pisaConfig('service-object'),
   })
 }


### PR DESCRIPTION
Without this function wrapping "fetchAttributes" would directly be calling PisaSales and as a consequence enforce a login - even for a user that is just visiting the homepage.

The bug was introduced in https://github.com/Scrivito/scrivito-portal-app/pull/681.