### PR TITLE
VideoWidget: Option to hide download button

### DIFF
--- a/src/Widgets/VideoWidget/VideoWidgetComponent.tsx
+++ b/src/Widgets/VideoWidget/VideoWidgetComponent.tsx
@@ -26,6 +26,7 @@ provideComponent(VideoWidget, ({ widget }) => {
       className={`video-widget aspect-ratio-${aspectRatio}`}
       src={src}
       content={widget}
+      controlsList={widget.get('noDownload') ? 'nodownload' : undefined}
       attribute="source"
       poster={posterUrl}
       controls={!isPlaceholderActive}

--- a/src/Widgets/VideoWidget/VideoWidgetEditingConfig.ts
+++ b/src/Widgets/VideoWidget/VideoWidgetEditingConfig.ts
@@ -29,8 +29,12 @@ provideEditingConfig(VideoWidget, {
         'This poster image is shown, until the video is loaded.' +
         ' Without an poster image, the browser may show the first frame of the video.',
     },
+    noDownload: {
+      title: 'Hide download button?',
+      description: 'Only supported by some browsers.',
+    },
   },
-  properties: ['source', 'poster', 'aspectRatio'],
+  properties: ['source', 'poster', 'aspectRatio', 'noDownload'],
   initialContent: {
     aspectRatio: '16to9',
   },

--- a/src/Widgets/VideoWidget/VideoWidgetObjClass.ts
+++ b/src/Widgets/VideoWidget/VideoWidgetObjClass.ts
@@ -4,6 +4,7 @@ export const VideoWidget = provideWidgetClass('VideoWidget', {
   attributes: {
     source: ['reference', { only: ['Video'] }],
     poster: ['reference', { only: ['Image'] }],
+    noDownload: 'boolean',
     aspectRatio: [
       'enum',
       { values: ['21to9', '16to9', '4to3', '1to1', '3to4', '9to16'] },


### PR DESCRIPTION
This option is currently only supported by chromium-based browsers (Chrome, Edge, Brave etc.). Firefox and Safari do _not_ support this option, since they both don't offer a download button at all (see https://github.com/whatwg/html/pull/6715).