### PR TITLE
Keep URL path if falling back to the default site

### DIFF
--- a/src/config/scrivitoSites.ts
+++ b/src/config/scrivitoSites.ts
@@ -85,28 +85,28 @@ export function isNoSitePresent(): boolean {
 }
 
 export async function ensureSiteIsPresent() {
-  if ((await load(currentSiteId)) === null) {
-    if (await load(isNoSitePresent)) {
-      ensureUserIsLoggedIn()
-      return
-    }
+  if (await load(currentSiteId)) return
 
-    const site = await load(getPreferredSite)
-    if (!site) return
-
-    const language = languageForUrl(window.location.href)
-    const slashesCount = language ? 2 : 1
-    const prefixLength = (language?.length || 0) + slashesCount
-    const path = window.location.pathname.substring(prefixLength)
-
-    if (!path) {
-      navigateTo(site)
-      return
-    }
-
-    const url = await load(() => urlFor(site))
-    window.location.assign([url, path].join(url.endsWith('/') ? '' : '/'))
+  if (await load(isNoSitePresent)) {
+    ensureUserIsLoggedIn()
+    return
   }
+
+  const site = await load(getPreferredSite)
+  if (!site) return
+
+  const language = languageForUrl(window.location.href)
+  const slashesCount = language ? 2 : 1
+  const prefixLength = (language?.length || 0) + slashesCount
+  const path = window.location.pathname.substring(prefixLength)
+
+  if (!path) {
+    navigateTo(site)
+    return
+  }
+
+  const url = await load(() => urlFor(site))
+  window.location.assign([url, path].join(url.endsWith('/') ? '' : '/'))
 }
 
 function getPreferredSite() {

--- a/src/config/scrivitoSites.ts
+++ b/src/config/scrivitoSites.ts
@@ -5,6 +5,7 @@ import {
   getInstanceId,
   load,
   navigateTo,
+  urlFor,
 } from 'scrivito'
 import { isMultitenancyEnabled } from './scrivitoTenants'
 import { ensureString } from '../utils/ensureString'
@@ -90,10 +91,21 @@ export async function ensureSiteIsPresent() {
       return
     }
 
-    navigateTo(() => {
-      const site = getPreferredSite()
-      return site
-    })
+    const site = await load(getPreferredSite)
+    if (!site) return
+
+    const language = languageForUrl(window.location.href)
+    const slashesCount = language ? 2 : 1
+    const prefixLength = (language?.length || 0) + slashesCount
+    const path = window.location.pathname.substring(prefixLength)
+
+    if (!path) {
+      navigateTo(site)
+      return
+    }
+
+    const url = await load(() => urlFor(site))
+    window.location.assign([url, path].join(url.endsWith('/') ? '' : '/'))
   }
 }
 

--- a/src/config/scrivitoSites.ts
+++ b/src/config/scrivitoSites.ts
@@ -91,17 +91,22 @@ export async function ensureSiteIsPresent() {
     }
 
     navigateTo(() => {
-      const websites = appWebsites() || []
-      const preferredLanguageOrder = [...window.navigator.languages, 'en', null]
-
-      for (const language of preferredLanguageOrder) {
-        const site = websites.find((site) => siteHasLanguage(site, language))
-        if (site) return site
-      }
-
-      return websites[0] || null
+      const site = getPreferredSite()
+      return site
     })
   }
+}
+
+function getPreferredSite() {
+  const websites = appWebsites() || []
+  const preferredLanguageOrder = [...window.navigator.languages, 'en', null]
+
+  for (const language of preferredLanguageOrder) {
+    const site = websites.find((site) => siteHasLanguage(site, language))
+    if (site) return site
+  }
+
+  return websites[0] || null
 }
 
 function getBaseAppUrl(): string {

--- a/src/config/scrivitoSites.ts
+++ b/src/config/scrivitoSites.ts
@@ -4,7 +4,6 @@ import {
   ensureUserIsLoggedIn,
   getInstanceId,
   load,
-  navigateTo,
   urlFor,
 } from 'scrivito'
 import { isMultitenancyEnabled } from './scrivitoTenants'
@@ -95,18 +94,11 @@ export async function ensureSiteIsPresent() {
   const site = await load(getPreferredSite)
   if (!site) return
 
-  const language = languageForUrl(window.location.href)
-  const slashesCount = language ? 2 : 1
-  const prefixLength = (language?.length || 0) + slashesCount
-  const path = window.location.pathname.substring(prefixLength)
+  const siteUrl = await load(() => urlFor(site))
+  const { pathname, search, hash } = window.location
+  const path = pathname === '/' ? '' : pathname
 
-  if (!path) {
-    navigateTo(site)
-    return
-  }
-
-  const url = await load(() => urlFor(site))
-  window.location.assign([url, path].join(url.endsWith('/') ? '' : '/'))
+  window.location.assign(`${siteUrl}${path}${search}${hash}`)
 }
 
 function getPreferredSite() {


### PR DESCRIPTION
This leads to better fallbacks for outdated/legacy permalinks, e.g.,

* https://example.com/contact -> https://example.com/en/contact (instead of https://example.com/en)
* https://example.com/en-US/contact -> https://example.com/en/contact (instead of https://example.com/en)