### PR TITLE
Restore original Vite chunk size limit

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -26,7 +26,12 @@ export default defineConfig(({ mode }) => {
         },
         output: {
           manualChunks: {
-            react: ['react-bootstrap', 'react-helmet-async', 'react-toastify'],
+            react: [
+              'react-bootstrap',
+              'react-dropzone',
+              'react-helmet-async',
+              'react-toastify',
+            ],
             scrivito: ['scrivito-neoletter-form-widgets'],
           },
         },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -18,12 +18,17 @@ export default defineConfig(({ mode }) => {
 
   return {
     build: {
-      chunkSizeWarningLimit: 900,
       outDir,
       rollupOptions: {
         input: {
           main: resolve(__dirname, 'index.html'),
           _scrivito_extensions: resolve(__dirname, '_scrivito_extensions.html'),
+        },
+        output: {
+          manualChunks: {
+            react: ['react-bootstrap', 'react-helmet-async', 'react-toastify'],
+            scrivito: ['scrivito-neoletter-form-widgets'],
+          },
         },
       },
     },


### PR DESCRIPTION
See https://v3.vitejs.dev/guide/build.html#chunking-strategy

I picked a chunking strategy where we chunk two large groups of vendor dependencies: React based and Scrivito based packages.