### PR TITLE
ProductCategory: Merge "description" into "metaDataDescription"

### DIFF
--- a/src/Objs/ProductCategory/ProductCategoryEditingConfig.ts
+++ b/src/Objs/ProductCategory/ProductCategoryEditingConfig.ts
@@ -13,7 +13,7 @@ provideEditingConfig(ProductCategory, {
   title: 'Product Category',
   thumbnail: Thumbnail,
   attributes: defaultPageEditingConfigAttributes,
-  properties: [...defaultPageProperties, 'description', 'image'],
+  properties: [...defaultPageProperties, 'image'],
   propertiesGroups: defaultPagePropertiesGroups,
   thumbnailForContent: (obj) => obj.get('image'),
   initialContent: defaultPageInitialContent,

--- a/src/Objs/ProductCategory/ProductCategoryObjClass.ts
+++ b/src/Objs/ProductCategory/ProductCategoryObjClass.ts
@@ -4,10 +4,9 @@ import { defaultPageAttributes } from '../defaultPageAttributes'
 export const ProductCategory = provideObjClass('ProductCategory', {
   attributes: {
     ...defaultPageAttributes,
-    description: 'string',
     image: ['reference', { only: ['Image'] }],
   },
-  extractTextAttributes: ['description'],
+  extractTextAttributes: ['metaDataDescription'],
 })
 
 export type ProductCategoryInstance = InstanceType<typeof ProductCategory>

--- a/src/Objs/ProductsOverview/ProductsOverviewComponent.tsx
+++ b/src/Objs/ProductsOverview/ProductsOverviewComponent.tsx
@@ -36,7 +36,7 @@ provideComponent(ProductsOverview, ({ page }) => {
                         />
                         <ContentTag
                           content={category}
-                          attribute="description"
+                          attribute="metaDataDescription"
                           tag="p"
                           className="small text-center m-0"
                         />


### PR DESCRIPTION
Both attributes are very similar and "metaDataDescription" also ready has a title. Better only use one of the two.

Content: https://edit.scrivito.com/d0a154d76edf2a7bd991fc658e700a1d~https://merge-description-into-metad.scrivito-portal-app.pages.dev/en/products-749ee4e15707e4ff?_scrivito_workspace_id=h530cb393e8ca441&_scrivito_display_mode=diff

This is a breaking change: The app will only show the correct values on the "Products" page, if both the app and the content are "in sync" => don't just merge.