### PR TITLE
[eslint] Use @arabasta/eslint-plugin-react

### DIFF
--- a/.knip.jsonc
+++ b/.knip.jsonc
@@ -21,7 +21,7 @@
     "@cloudflare/workers-types", // used by functions/*
 
     // used by eslint.config.mjs; Workaround for https://github.com/webpro-nl/knip/issues/818
-    "@arabasta/eslint-plugin-require-useeffect-dependency-array",
+    "@arabasta/eslint-plugin-react",
     "eslint-plugin-import",
     "eslint-plugin-react",
     "eslint-plugin-react-hooks",

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -19,7 +19,7 @@ export default [
   ...fixupConfigRules(
     compat.extends(
       'eslint:recommended',
-      'plugin:@arabasta/require-useeffect-dependency-array/recommended-legacy',
+      'plugin:@arabasta/react/recommended-legacy',
       'plugin:@typescript-eslint/recommended',
       'plugin:react/recommended',
       'plugin:react/jsx-runtime',

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "speakingurl": "^14.0.1"
       },
       "devDependencies": {
-        "@arabasta/eslint-plugin-require-useeffect-dependency-array": "^1.0.9",
+        "@arabasta/eslint-plugin-react": "^1.0.0",
         "@cloudflare/workers-types": "^4.20250129.0",
         "@eslint/compat": "^1.2.6",
         "@eslint/eslintrc": "^3.2.0",
@@ -87,10 +87,10 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/@arabasta/eslint-plugin-require-useeffect-dependency-array": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/@arabasta/eslint-plugin-require-useeffect-dependency-array/-/eslint-plugin-require-useeffect-dependency-array-1.0.9.tgz",
-      "integrity": "sha512-yto2hiAL6KC2xPvZU1CqJQlZWUNrTuOa86fw5BygwWBURqL99uilVuVa82CgvOSWcT1STrp/WBYz0dKHPdJ7Rw==",
+    "node_modules/@arabasta/eslint-plugin-react": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@arabasta/eslint-plugin-react/-/eslint-plugin-react-1.0.0.tgz",
+      "integrity": "sha512-9HDwS9sUdbefKVdDCDSPb75z9F/ptgwteZNyW9fmCjbNmXAzTlFlJpvySCembz8zvim2Z1T6R7m3RSjg7hy7pw==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "speakingurl": "^14.0.1"
   },
   "devDependencies": {
-    "@arabasta/eslint-plugin-require-useeffect-dependency-array": "^1.0.9",
+    "@arabasta/eslint-plugin-react": "^1.0.0",
     "@cloudflare/workers-types": "^4.20250129.0",
     "@eslint/compat": "^1.2.6",
     "@eslint/eslintrc": "^3.2.0",


### PR DESCRIPTION
Instead of previous "@arabasta/eslint-plugin-require-useeffect-dependency-array"

Otherwise npm i will print:

```
npm warn deprecated @arabasta/eslint-plugin-require-useeffect-dependency-array@1.0.9: Use @arabasta/eslint-plugin-react module instead
```