### PR TITLE
ContentSearchResult

### DIFF
--- a/src/Data/ContentSearchResult/ContentSearchResultDataClass.ts
+++ b/src/Data/ContentSearchResult/ContentSearchResultDataClass.ts
@@ -73,8 +73,8 @@ function objToResult(obj: Obj) {
   const imageId = isImage(imageReference) ? imageReference.id() : null
 
   const snippet =
-    extractText(obj, { length: 300 }) ||
-    ensureString(obj.get('metaDataDescription'))
+    ensureString(obj.get('metaDataDescription')) ||
+    extractText(obj, { length: 300 })
 
   return {
     _id: obj.id(),

--- a/src/Data/ContentSearchResult/ContentSearchResultDataClass.ts
+++ b/src/Data/ContentSearchResult/ContentSearchResultDataClass.ts
@@ -48,7 +48,7 @@ export const ContentSearchResult = provideDataClass('ContentSearchResult', {
 
       const objSearch = Obj.whereFullTextOf('*', 'matches', search)
         .andNot('_objClass', 'equals', BLACKLIST_OBJ_CLASSES)
-        .and('_dataParam', 'equals', null) // Ignore data details pages
+        .and('_dataParam', 'equals', null) // Ignore data details pages. See issue #11592.
         .andNot('excludeFromSearch', 'equals', true)
 
       const limit = params.limit()

--- a/src/Data/ContentSearchResult/ContentSearchResultDataClass.ts
+++ b/src/Data/ContentSearchResult/ContentSearchResultDataClass.ts
@@ -70,7 +70,7 @@ export const ContentSearchResult = provideDataClass('ContentSearchResult', {
 
 function objToResult(obj: Obj) {
   const imageReference = obj.get('image')
-  const image = isImage(imageReference) ? imageReference.id() : null
+  const imageId = isImage(imageReference) ? imageReference.id() : null
 
   const snippet =
     extractText(obj, { length: 300 }) ||
@@ -78,7 +78,7 @@ function objToResult(obj: Obj) {
 
   return {
     _id: obj.id(),
-    image,
+    image: imageId,
     snippet: removePlaceholders(snippet),
     title: removePlaceholders(objTitle(obj)),
     url: urlFor(obj),

--- a/src/Data/ContentSearchResult/ContentSearchResultDataClass.ts
+++ b/src/Data/ContentSearchResult/ContentSearchResultDataClass.ts
@@ -31,16 +31,16 @@ export const ContentSearchResult = provideDataClass('ContentSearchResult', {
   },
   title: async () =>
     (await load(currentLanguage)) === 'de'
-      ? 'Inhalts-Suchergebnis'
-      : 'Content Search Result',
+      ? 'Suchtreffer (Content)'
+      : 'Search result (content)',
   connection: {
     async index(params) {
       if (Object.keys(params.filters()).length > 0) {
-        throw new Error('Filtering is not supported for CMS Search Results.')
+        throw new Error('Search result (content) does not support filtering.')
       }
 
       if (params.order().length > 0) {
-        throw new Error('Sorting is not supported for CMS Search Results.')
+        throw new Error('Search result (content) does not support sorting.')
       }
 
       const search = params.search()

--- a/src/Data/ContentSearchResult/ContentSearchResultDataClass.ts
+++ b/src/Data/ContentSearchResult/ContentSearchResultDataClass.ts
@@ -21,7 +21,10 @@ export const ContentSearchResult = provideDataClass('ContentSearchResult', {
         'reference',
         { title: lang === 'de' ? 'Bild' : 'Image', to: 'Image' },
       ],
-      snippet: ['string', { title: lang === 'de' ? 'Schnipsel' : 'Snippet' }],
+      snippet: [
+        'string',
+        { title: lang === 'de' ? 'Textausschnitt' : 'Snippet' },
+      ],
       title: ['string', { title: lang === 'de' ? 'Titel' : 'Title' }],
       url: ['string', { title: 'URL' }],
     }

--- a/src/Data/ContentSearchResult/ContentSearchResultDataClass.ts
+++ b/src/Data/ContentSearchResult/ContentSearchResultDataClass.ts
@@ -1,0 +1,89 @@
+import {
+  currentLanguage,
+  extractText,
+  load,
+  Obj,
+  provideDataClass,
+  urlFor,
+} from 'scrivito'
+import { objTitle } from '../../utils/objTitle'
+import { ensureString } from '../../utils/ensureString'
+import { isImage } from '../../Objs/Image/ImageObjClass'
+
+const BLACKLIST_OBJ_CLASSES = ['Image', 'Redirect', 'Video']
+
+export const ContentSearchResult = provideDataClass('ContentSearchResult', {
+  attributes: async () => {
+    const lang = await load(currentLanguage)
+
+    return {
+      image: [
+        'reference',
+        { title: lang === 'de' ? 'Bild' : 'Image', to: 'Image' },
+      ],
+      snippet: ['string', { title: lang === 'de' ? 'Schnipsel' : 'Snippet' }],
+      title: ['string', { title: lang === 'de' ? 'Titel' : 'Title' }],
+      url: ['string', { title: 'URL' }],
+    }
+  },
+  title: async () =>
+    (await load(currentLanguage)) === 'de'
+      ? 'Inhalts-Suchergebnis'
+      : 'Content Search Result',
+  connection: {
+    async index(params) {
+      if (Object.keys(params.filters()).length > 0) {
+        throw new Error('Filtering is not supported for CMS Search Results.')
+      }
+
+      if (params.order().length > 0) {
+        throw new Error('Sorting is not supported for CMS Search Results.')
+      }
+
+      const search = params.search()
+      if (!search) return { results: [], count: 0 }
+
+      const objSearch = Obj.whereFullTextOf('*', 'matches', search)
+        .andNot('_objClass', 'equals', BLACKLIST_OBJ_CLASSES)
+        .and('_dataParam', 'equals', null) // Ignore data details pages
+        .andNot('excludeFromSearch', 'equals', true)
+
+      const limit = params.limit()
+
+      const { results, count } = await load(() => ({
+        results: objSearch
+          .take(limit)
+          .slice(Number(params.continuation() ?? 0))
+          .map(objToResult),
+        count: objSearch.count(),
+      }))
+
+      const continuation = limit < count ? limit.toString() : undefined
+
+      return { continuation, count, results }
+    },
+  },
+})
+
+function objToResult(obj: Obj) {
+  const imageReference = obj.get('image')
+  const image = isImage(imageReference) ? imageReference.id() : null
+
+  const snippet =
+    extractText(obj, { length: 300 }) ||
+    ensureString(obj.get('metaDataDescription'))
+
+  return {
+    _id: obj.id(),
+    image,
+    snippet: removePlaceholders(snippet),
+    title: removePlaceholders(objTitle(obj)),
+    url: urlFor(obj),
+  }
+}
+
+function removePlaceholders(text: string): string {
+  // This is only a "good enough" implementation.
+  // It might remove more than just SDK placeholders.
+  return text.replace(/__.+?__/gi, '')
+}

--- a/src/Data/ContentSearchResult/ContentSearchResultDataClass.ts
+++ b/src/Data/ContentSearchResult/ContentSearchResultDataClass.ts
@@ -10,7 +10,7 @@ import { objTitle } from '../../utils/objTitle'
 import { ensureString } from '../../utils/ensureString'
 import { isImage } from '../../Objs/Image/ImageObjClass'
 
-const BLACKLIST_OBJ_CLASSES = ['Image', 'Redirect', 'Video']
+const BLACKLIST_OBJ_CLASSES = ['Dropdown', 'Font', 'Image', 'Redirect', 'Video']
 
 export const ContentSearchResult = provideDataClass('ContentSearchResult', {
   attributes: async () => {

--- a/src/Data/localStorageDataConnection.ts
+++ b/src/Data/localStorageDataConnection.ts
@@ -62,13 +62,13 @@ export function localStorageDataConnection(
 
       const orderedItems = orderItems(matchingItems, params.order())
 
-      const offset =
-        params.continuation() === undefined ? 0 : Number(params.continuation())
-      const newOffset = offset + 10
-
-      const results = orderedItems.slice(offset, newOffset)
+      const limit = params.limit()
+      const results = orderedItems.slice(
+        Number(params.continuation() ?? 0),
+        limit,
+      )
       const continuation =
-        newOffset < orderedItems.length ? newOffset.toString() : undefined
+        limit < orderedItems.length ? limit.toString() : undefined
 
       return { results, continuation, count: orderedItems.length }
     },

--- a/src/Widgets/SearchResultsWidget/SearchResult.tsx
+++ b/src/Widgets/SearchResultsWidget/SearchResult.tsx
@@ -69,8 +69,8 @@ const TextDescription = connect(function TextResult({
   const searchWords = query.split(/\s+/)
 
   const description =
-    extractText(searchResult, { length: 300 }) ||
-    ensureString(searchResult.get('metaDataDescription'))
+    ensureString(searchResult.get('metaDataDescription')) ||
+    extractText(searchResult, { length: 300 })
 
   const shortDescription = truncate(useResolvedStringValue(description), {
     length: 200,

--- a/src/Widgets/SearchResultsWidget/SearchResultsWidgetComponent.tsx
+++ b/src/Widgets/SearchResultsWidget/SearchResultsWidgetComponent.tsx
@@ -18,7 +18,7 @@ import {
 } from './SearchResultsWidgetClass'
 import { Loading } from '../../Components/Loading'
 
-const BLACKLIST_OBJ_CLASSES = ['Image', 'Redirect', 'Video']
+const BLACKLIST_OBJ_CLASSES = ['Dropdown', 'Font', 'Image', 'Redirect', 'Video']
 
 provideComponent(SearchResultsWidget, ({ widget }) => {
   const query = ensureString(currentPageParams().q).trim()

--- a/src/Widgets/SearchResultsWidget/SearchResultsWidgetComponent.tsx
+++ b/src/Widgets/SearchResultsWidget/SearchResultsWidgetComponent.tsx
@@ -28,7 +28,7 @@ provideComponent(SearchResultsWidget, ({ widget }) => {
 
   const search = Obj.whereFullTextOf('*', 'matches', query)
     .andNot('_objClass', 'equals', BLACKLIST_OBJ_CLASSES)
-    .and('_dataParam', 'equals', null) // Ignore data details pages
+    .and('_dataParam', 'equals', null) // Ignore data details pages. See issue #11592.
     .andNot('excludeFromSearch', 'equals', true)
 
   const readMoreLabel = widget.get('readMoreLabel')


### PR DESCRIPTION
Moves search logic of https://github.com/Scrivito/scrivito-portal-app/blob/main/src/Widgets/SearchResultsWidget/SearchResultsWidgetComponent.tsx into a data class. Overall goal: Get rid of `SearchResultsWidget` and use data search primitives.

Working copy to test it out: https://edit.scrivito.com/d0a154d76edf2a7bd991fc658e700a1d~https://contentsearchresult.scrivito-portal-app.pages.dev/en/search-results?q=Test&_scrivito_workspace_id=r228d708e9d6524d&_scrivito_display_mode=view

Please not that other PRs are still needed before the content can go live.