### PR TITLE
Search improvements + better loader

### DIFF
--- a/src/Components/DataBatchContext.tsx
+++ b/src/Components/DataBatchContext.tsx
@@ -1,4 +1,4 @@
-import { createContext, useState } from 'react'
+import { createContext, useCallback, useState } from 'react'
 import { connect, useData, Obj, Widget, ContentTag } from 'scrivito'
 
 export const DataBatchContext = createContext<{
@@ -28,7 +28,15 @@ export const DataBatchContextProvider = connect(
     const configuredLimit = dataScope.limit() ?? 20
     const [limit, setLimit] = useState(configuredLimit)
     const [initialLimit, setInitialLimit] = useState(configuredLimit)
-    const [search, setSearch] = useState('')
+    const [search, setSearchState] = useState('')
+
+    const setSearch = useCallback(
+      (query: string) => {
+        setSearchState(query)
+        setLimit(configuredLimit)
+      },
+      [configuredLimit],
+    )
 
     if (initialLimit !== configuredLimit) {
       setInitialLimit(configuredLimit)

--- a/src/Components/DataBatchContext.tsx
+++ b/src/Components/DataBatchContext.tsx
@@ -2,10 +2,12 @@ import { createContext, useCallback, useState } from 'react'
 import { connect, useData, Obj, Widget, ContentTag } from 'scrivito'
 
 export const DataBatchContext = createContext<{
+  combinedLoaderKey: string
   hasMore: () => boolean
   loadMore: () => void
   setSearch?: (query: string) => void
 }>({
+  combinedLoaderKey: '',
   hasMore: () => true,
   loadMore: () => {
     throw new Error('loadMore is not provided!')
@@ -43,7 +45,7 @@ export const DataBatchContextProvider = connect(
       setLimit(configuredLimit)
     }
 
-    const key = [
+    const baseKeys = [
       'DataBatchContextProvider',
       content.id(),
       attribute,
@@ -51,7 +53,9 @@ export const DataBatchContextProvider = connect(
       tag,
       search,
       // limit is intentionally not included in the key. Otherwise the component would show a loading spinner on every "load more" click.
-    ].join('-')
+    ]
+
+    const combinedLoaderKey = [...baseKeys, limit].join('-')
 
     const transform = { limit, search }
 
@@ -69,11 +73,13 @@ export const DataBatchContextProvider = connect(
     const loadMore = () => setLimit((prevLimit) => prevLimit + configuredLimit)
 
     return (
-      <DataBatchContext.Provider value={{ hasMore, loadMore, setSearch }}>
+      <DataBatchContext.Provider
+        value={{ combinedLoaderKey, hasMore, loadMore, setSearch }}
+      >
         <ContentTag
           tag={tag}
           id={id}
-          key={key}
+          key={baseKeys.join('-')}
           content={content}
           attribute={attribute}
           dataContext={dataScope.transform(transform)}

--- a/src/Components/DataBatchContext.tsx
+++ b/src/Components/DataBatchContext.tsx
@@ -30,11 +30,11 @@ export const DataBatchContextProvider = connect(
     const configuredLimit = dataScope.limit() ?? 20
     const [limit, setLimit] = useState(configuredLimit)
     const [initialLimit, setInitialLimit] = useState(configuredLimit)
-    const [search, setSearchState] = useState('')
+    const [query, setQuery] = useState('')
 
     const setSearch = useCallback(
       (query: string) => {
-        setSearchState(query)
+        setQuery(query)
         setLimit(configuredLimit)
       },
       [configuredLimit],
@@ -51,13 +51,13 @@ export const DataBatchContextProvider = connect(
       attribute,
       id,
       tag,
-      search,
+      query,
       // limit is intentionally not included in the key. Otherwise the component would show a loading spinner on every "load more" click.
     ]
 
     const combinedLoaderKey = [...baseKeys, limit].join('-')
 
-    const transform = { limit, search }
+    const transform = { limit, search: query }
 
     const hasMore = () => {
       try {

--- a/src/Components/DataBatchContext.tsx
+++ b/src/Components/DataBatchContext.tsx
@@ -45,17 +45,16 @@ export const DataBatchContextProvider = connect(
       setLimit(configuredLimit)
     }
 
-    const baseKeys = [
+    const dataKeys = [
       'DataBatchContextProvider',
       content.id(),
       attribute,
       id,
       tag,
       query,
-      // limit is intentionally not included in the key. Otherwise the component would show a loading spinner on every "load more" click.
     ]
 
-    const batchLoaderKey = [...baseKeys, limit].join('-')
+    const batchLoaderKey = [...dataKeys, limit].join('-')
 
     const transform = { limit, search: query }
 
@@ -79,7 +78,7 @@ export const DataBatchContextProvider = connect(
         <ContentTag
           tag={tag}
           id={id}
-          key={baseKeys.join('-')}
+          key={dataKeys.join('-')}
           content={content}
           attribute={attribute}
           dataContext={dataScope.transform(transform)}

--- a/src/Components/DataBatchContext.tsx
+++ b/src/Components/DataBatchContext.tsx
@@ -1,4 +1,4 @@
-import { createContext, useCallback, useState } from 'react'
+import { createContext, useEffect, useState } from 'react'
 import { connect, useData, Obj, Widget, ContentTag } from 'scrivito'
 
 export const DataBatchContext = createContext<{
@@ -29,21 +29,11 @@ export const DataBatchContextProvider = connect(
     const dataScope = useData()
     const configuredLimit = dataScope.limit() ?? 20
     const [limit, setLimit] = useState(configuredLimit)
-    const [initialLimit, setInitialLimit] = useState(configuredLimit)
-    const [query, setQuery] = useState('')
+    const [search, setSearch] = useState('')
 
-    const setSearch = useCallback(
-      (query: string) => {
-        setQuery(query)
-        setLimit(configuredLimit)
-      },
-      [configuredLimit],
-    )
-
-    if (initialLimit !== configuredLimit) {
-      setInitialLimit(configuredLimit)
+    useEffect(() => {
       setLimit(configuredLimit)
-    }
+    }, [configuredLimit, search])
 
     const dataKeys = [
       'DataBatchContextProvider',
@@ -51,12 +41,12 @@ export const DataBatchContextProvider = connect(
       attribute,
       id,
       tag,
-      query,
+      search,
     ]
 
     const batchLoaderKey = [...dataKeys, limit].join('-')
 
-    const transform = { limit, search: query }
+    const transform = { limit, search }
 
     const hasMore = () => {
       try {

--- a/src/Components/DataBatchContext.tsx
+++ b/src/Components/DataBatchContext.tsx
@@ -2,12 +2,12 @@ import { createContext, useCallback, useState } from 'react'
 import { connect, useData, Obj, Widget, ContentTag } from 'scrivito'
 
 export const DataBatchContext = createContext<{
-  combinedLoaderKey: string
+  batchLoaderKey: string
   hasMore: () => boolean
   loadMore: () => void
   setSearch?: (query: string) => void
 }>({
-  combinedLoaderKey: '',
+  batchLoaderKey: '',
   hasMore: () => true,
   loadMore: () => {
     throw new Error('loadMore is not provided!')
@@ -55,7 +55,7 @@ export const DataBatchContextProvider = connect(
       // limit is intentionally not included in the key. Otherwise the component would show a loading spinner on every "load more" click.
     ]
 
-    const combinedLoaderKey = [...baseKeys, limit].join('-')
+    const batchLoaderKey = [...baseKeys, limit].join('-')
 
     const transform = { limit, search: query }
 
@@ -74,7 +74,7 @@ export const DataBatchContextProvider = connect(
 
     return (
       <DataBatchContext.Provider
-        value={{ combinedLoaderKey, hasMore, loadMore, setSearch }}
+        value={{ batchLoaderKey, hasMore, loadMore, setSearch }}
       >
         <ContentTag
           tag={tag}

--- a/src/Widgets/DataColumnListWidget/DataColumnListWidgetComponent.tsx
+++ b/src/Widgets/DataColumnListWidget/DataColumnListWidgetComponent.tsx
@@ -11,7 +11,7 @@ provideComponent(
   DataColumnListWidget,
   ({ widget }) => {
     const dataScope = useData()
-    const { combinedLoaderKey, hasMore } = useContext(DataBatchContext)
+    const { combinedLoaderKey } = useContext(DataBatchContext)
     let dataError: unknown
 
     try {
@@ -47,11 +47,7 @@ provideComponent(
             />
           ))}
         </div>
-        <DataBatchLoadingIndicator
-          dataScope={dataScope}
-          hasMore={hasMore}
-          key={combinedLoaderKey}
-        />
+        <DataBatchLoadingIndicator key={combinedLoaderKey} />
       </>
     )
   },

--- a/src/Widgets/DataColumnListWidget/DataColumnListWidgetComponent.tsx
+++ b/src/Widgets/DataColumnListWidget/DataColumnListWidgetComponent.tsx
@@ -5,7 +5,7 @@ import { Loading } from '../../Components/Loading'
 import { DataErrorEditorNote } from '../../Components/DataErrorEditorNote'
 import { useContext } from 'react'
 import { DataBatchContext } from '../../Components/DataBatchContext'
-import { CombinedLoader } from '../DataWidget/CombinedLoader'
+import { DataBatchLoadingIndicator } from '../DataWidget/DataBatchLoadingIndicator'
 
 provideComponent(
   DataColumnListWidget,
@@ -47,7 +47,7 @@ provideComponent(
             />
           ))}
         </div>
-        <CombinedLoader
+        <DataBatchLoadingIndicator
           dataScope={dataScope}
           hasMore={hasMore}
           key={combinedLoaderKey}

--- a/src/Widgets/DataColumnListWidget/DataColumnListWidgetComponent.tsx
+++ b/src/Widgets/DataColumnListWidget/DataColumnListWidgetComponent.tsx
@@ -3,11 +3,15 @@ import { DataColumnListWidget } from './DataColumnListWidgetClass'
 import { EditorNote } from '../../Components/EditorNote'
 import { Loading } from '../../Components/Loading'
 import { DataErrorEditorNote } from '../../Components/DataErrorEditorNote'
+import { useContext } from 'react'
+import { DataBatchContext } from '../../Components/DataBatchContext'
+import { CombinedLoader } from '../DataWidget/CombinedLoader'
 
 provideComponent(
   DataColumnListWidget,
   ({ widget }) => {
     const dataScope = useData()
+    const { combinedLoaderKey, hasMore } = useContext(DataBatchContext)
     let dataError: unknown
 
     try {
@@ -31,17 +35,24 @@ provideComponent(
     const columnsCount = widget.get('columnsCount') || '2'
 
     return (
-      <div className={`row row-cols-1 row-cols-md-${columnsCount}`}>
-        {dataItems.map((dataItem) => (
-          <ContentTag
-            content={widget}
-            attribute="content"
-            className="col"
-            dataContext={dataItem}
-            key={dataItem.id()}
-          />
-        ))}
-      </div>
+      <>
+        <div className={`row row-cols-1 row-cols-md-${columnsCount}`}>
+          {dataItems.map((dataItem) => (
+            <ContentTag
+              content={widget}
+              attribute="content"
+              className="col"
+              dataContext={dataItem}
+              key={dataItem.id()}
+            />
+          ))}
+        </div>
+        <CombinedLoader
+          dataScope={dataScope}
+          hasMore={hasMore}
+          key={combinedLoaderKey}
+        />
+      </>
     )
   },
   { loading: Loading },

--- a/src/Widgets/DataColumnListWidget/DataColumnListWidgetComponent.tsx
+++ b/src/Widgets/DataColumnListWidget/DataColumnListWidgetComponent.tsx
@@ -11,7 +11,7 @@ provideComponent(
   DataColumnListWidget,
   ({ widget }) => {
     const dataScope = useData()
-    const { combinedLoaderKey } = useContext(DataBatchContext)
+    const { batchLoaderKey } = useContext(DataBatchContext)
     let dataError: unknown
 
     try {
@@ -47,7 +47,7 @@ provideComponent(
             />
           ))}
         </div>
-        <DataBatchLoadingIndicator key={combinedLoaderKey} />
+        <DataBatchLoadingIndicator key={batchLoaderKey} />
       </>
     )
   },

--- a/src/Widgets/DataWidget/CombinedLoader.tsx
+++ b/src/Widgets/DataWidget/CombinedLoader.tsx
@@ -1,0 +1,19 @@
+import { connect, DataScope } from 'scrivito'
+import { Loading } from '../../Components/Loading'
+
+export const CombinedLoader = connect(
+  function CombinedLoader({
+    dataScope,
+    hasMore,
+  }: {
+    dataScope: DataScope
+    hasMore: () => boolean
+  }) {
+    // use side-effects to trigger loading
+    dataScope.take()
+    hasMore()
+
+    return null
+  },
+  { loading: Loading },
+)

--- a/src/Widgets/DataWidget/DataBatchLoadingIndicator.tsx
+++ b/src/Widgets/DataWidget/DataBatchLoadingIndicator.tsx
@@ -8,7 +8,7 @@ export const DataBatchLoadingIndicator = connect(
     const dataScope = useData()
     const { hasMore } = useContext(DataBatchContext)
 
-    // use side-effects to trigger loading
+    // subscribe to dataScope.take() and hasMore() to trigger Loading
     dataScope.take()
     hasMore()
 

--- a/src/Widgets/DataWidget/DataBatchLoadingIndicator.tsx
+++ b/src/Widgets/DataWidget/DataBatchLoadingIndicator.tsx
@@ -8,7 +8,7 @@ export const DataBatchLoadingIndicator = connect(
     const dataScope = useData()
     const { hasMore } = useContext(DataBatchContext)
 
-    // subscribe to dataScope.take() and hasMore() to trigger Loading
+    // subscribe to dataScope.take() and hasMore() loading
     dataScope.take()
     hasMore()
 

--- a/src/Widgets/DataWidget/DataBatchLoadingIndicator.tsx
+++ b/src/Widgets/DataWidget/DataBatchLoadingIndicator.tsx
@@ -1,8 +1,8 @@
 import { connect, DataScope } from 'scrivito'
 import { Loading } from '../../Components/Loading'
 
-export const CombinedLoader = connect(
-  function CombinedLoader({
+export const DataBatchLoadingIndicator = connect(
+  function DataBatchLoadingIndicator({
     dataScope,
     hasMore,
   }: {

--- a/src/Widgets/DataWidget/DataBatchLoadingIndicator.tsx
+++ b/src/Widgets/DataWidget/DataBatchLoadingIndicator.tsx
@@ -1,14 +1,13 @@
-import { connect, DataScope } from 'scrivito'
+import { connect, useData } from 'scrivito'
 import { Loading } from '../../Components/Loading'
+import { useContext } from 'react'
+import { DataBatchContext } from '../../Components/DataBatchContext'
 
 export const DataBatchLoadingIndicator = connect(
-  function DataBatchLoadingIndicator({
-    dataScope,
-    hasMore,
-  }: {
-    dataScope: DataScope
-    hasMore: () => boolean
-  }) {
+  function DataBatchLoadingIndicator() {
+    const dataScope = useData()
+    const { hasMore } = useContext(DataBatchContext)
+
     // use side-effects to trigger loading
     dataScope.take()
     hasMore()

--- a/src/Widgets/DataWidget/DataWidgetComponent.tsx
+++ b/src/Widgets/DataWidget/DataWidgetComponent.tsx
@@ -3,11 +3,15 @@ import { DataWidget } from './DataWidgetClass'
 import { EditorNote } from '../../Components/EditorNote'
 import { Loading } from '../../Components/Loading'
 import { DataErrorEditorNote } from '../../Components/DataErrorEditorNote'
+import { DataBatchContext } from '../../Components/DataBatchContext'
+import { useContext } from 'react'
+import { CombinedLoader } from './CombinedLoader'
 
 provideComponent(
   DataWidget,
   ({ widget }) => {
     const dataScope = useData()
+    const { combinedLoaderKey, hasMore } = useContext(DataBatchContext)
     let dataError: unknown
 
     try {
@@ -37,6 +41,11 @@ provideComponent(
             key={dataItem.id()}
           />
         ))}
+        <CombinedLoader
+          dataScope={dataScope}
+          hasMore={hasMore}
+          key={combinedLoaderKey}
+        />
       </>
     )
   },

--- a/src/Widgets/DataWidget/DataWidgetComponent.tsx
+++ b/src/Widgets/DataWidget/DataWidgetComponent.tsx
@@ -5,7 +5,7 @@ import { Loading } from '../../Components/Loading'
 import { DataErrorEditorNote } from '../../Components/DataErrorEditorNote'
 import { DataBatchContext } from '../../Components/DataBatchContext'
 import { useContext } from 'react'
-import { CombinedLoader } from './CombinedLoader'
+import { DataBatchLoadingIndicator } from './DataBatchLoadingIndicator'
 
 provideComponent(
   DataWidget,
@@ -41,7 +41,7 @@ provideComponent(
             key={dataItem.id()}
           />
         ))}
-        <CombinedLoader
+        <DataBatchLoadingIndicator
           dataScope={dataScope}
           hasMore={hasMore}
           key={combinedLoaderKey}

--- a/src/Widgets/DataWidget/DataWidgetComponent.tsx
+++ b/src/Widgets/DataWidget/DataWidgetComponent.tsx
@@ -11,7 +11,7 @@ provideComponent(
   DataWidget,
   ({ widget }) => {
     const dataScope = useData()
-    const { combinedLoaderKey, hasMore } = useContext(DataBatchContext)
+    const { combinedLoaderKey } = useContext(DataBatchContext)
     let dataError: unknown
 
     try {
@@ -41,11 +41,7 @@ provideComponent(
             key={dataItem.id()}
           />
         ))}
-        <DataBatchLoadingIndicator
-          dataScope={dataScope}
-          hasMore={hasMore}
-          key={combinedLoaderKey}
-        />
+        <DataBatchLoadingIndicator key={combinedLoaderKey} />
       </>
     )
   },

--- a/src/Widgets/DataWidget/DataWidgetComponent.tsx
+++ b/src/Widgets/DataWidget/DataWidgetComponent.tsx
@@ -11,7 +11,7 @@ provideComponent(
   DataWidget,
   ({ widget }) => {
     const dataScope = useData()
-    const { combinedLoaderKey } = useContext(DataBatchContext)
+    const { batchLoaderKey } = useContext(DataBatchContext)
     let dataError: unknown
 
     try {
@@ -41,7 +41,7 @@ provideComponent(
             key={dataItem.id()}
           />
         ))}
-        <DataBatchLoadingIndicator key={combinedLoaderKey} />
+        <DataBatchLoadingIndicator key={batchLoaderKey} />
       </>
     )
   },


### PR DESCRIPTION
Motivation: When someone clicks on "Load more" a spinner should be shown until all informations are available (more items in the load and the status of "hasMore").


See effect by artificially slowing down `localStorageDataConnection#index`:

```ts
await new Promise((resolve) => setTimeout(resolve, 1500))
```