### PR TITLE
Subscription supporting filter

### DIFF
--- a/src/Data/Subscription/SubscriptionDataClass.ts
+++ b/src/Data/Subscription/SubscriptionDataClass.ts
@@ -35,7 +35,10 @@ export const Subscription = provideDataClass('Subscription', {
         unfilteredSubscriptions,
       )
 
-      return { results: subscriptions, count: subscriptions.length }
+      return {
+        results: subscriptions.slice(0, params.limit()),
+        count: subscriptions.length,
+      }
     },
     async get(id: string) {
       return (await fetchSubscriptions()).find((sub) => sub._id === id) || null

--- a/src/Data/Subscription/SubscriptionDataClass.ts
+++ b/src/Data/Subscription/SubscriptionDataClass.ts
@@ -29,6 +29,10 @@ export const Subscription = provideDataClass('Subscription', {
   },
   connection: {
     async index(params) {
+      if (params.search()) {
+        throw new Error('Searching is not supported for subscriptions.')
+      }
+
       const unfilteredSubscriptions = await fetchSubscriptions()
       const subscriptions = filterDataItems(
         params.filters(),

--- a/src/Data/Subscription/SubscriptionDataClass.ts
+++ b/src/Data/Subscription/SubscriptionDataClass.ts
@@ -1,6 +1,7 @@
 import { currentLanguage, load, provideDataClass } from 'scrivito'
 import { neoletterClient } from '../neoletterClient'
 import { filterDataItems } from '../filterDataItems'
+import { orderDataItems } from '../orderDataItems'
 
 interface Topic {
   id: string
@@ -33,15 +34,21 @@ export const Subscription = provideDataClass('Subscription', {
         throw new Error('Searching is not supported for subscriptions.')
       }
 
-      const unfilteredSubscriptions = await fetchSubscriptions()
-      const subscriptions = filterDataItems(
+      const subscriptions = await fetchSubscriptions()
+
+      const filteredSubscriptions = filterDataItems(
         params.filters(),
-        unfilteredSubscriptions,
+        subscriptions,
+      )
+
+      const orderedSubscriptions = orderDataItems(
+        params.order(),
+        filteredSubscriptions,
       )
 
       return {
-        results: subscriptions.slice(0, params.limit()),
-        count: subscriptions.length,
+        results: orderedSubscriptions.slice(0, params.limit()),
+        count: orderedSubscriptions.length,
       }
     },
     async get(id: string) {

--- a/src/Data/Subscription/SubscriptionDataClass.ts
+++ b/src/Data/Subscription/SubscriptionDataClass.ts
@@ -1,5 +1,6 @@
 import { currentLanguage, load, provideDataClass } from 'scrivito'
 import { neoletterClient } from '../neoletterClient'
+import { filterDataItems } from '../filterDataItems'
 
 interface Topic {
   id: string
@@ -27,8 +28,13 @@ export const Subscription = provideDataClass('Subscription', {
     }
   },
   connection: {
-    async index() {
-      const subscriptions = await fetchSubscriptions()
+    async index(params) {
+      const unfilteredSubscriptions = await fetchSubscriptions()
+      const subscriptions = filterDataItems(
+        params.filters(),
+        unfilteredSubscriptions,
+      )
+
       return { results: subscriptions, count: subscriptions.length }
     },
     async get(id: string) {

--- a/src/Data/filterDataItems.ts
+++ b/src/Data/filterDataItems.ts
@@ -1,0 +1,61 @@
+import { DataConnectionFilters, DataConnectionResultItem } from 'scrivito'
+
+export function filterDataItems(
+  filters: DataConnectionFilters,
+  items: DataConnectionResultItem[],
+): DataConnectionResultItem[] {
+  return items.filter((item) =>
+    Object.entries(filters).every(([filterAttribute, filter]) => {
+      const itemValue = item[filterAttribute]
+      const subFilters = filter.operator === 'and' ? filter.value : [filter]
+
+      return subFilters.every(({ value: filterValue, opCode }) =>
+        compare({ itemValue, filterValue, opCode }),
+      )
+    }),
+  )
+}
+
+const comparators = {
+  gt: (a: string | number, b: string | number) => a > b,
+  lt: (a: string | number, b: string | number) => a < b,
+  gte: (a: string | number, b: string | number) => a >= b,
+  lte: (a: string | number, b: string | number) => a <= b,
+}
+
+function compare({
+  itemValue,
+  filterValue,
+  opCode,
+}: {
+  itemValue: unknown
+  filterValue: string | number | boolean | null
+  opCode: 'eq' | 'neq' | 'gt' | 'lt' | 'gte' | 'lte'
+}): boolean {
+  if (opCode !== 'eq' && opCode !== 'neq') {
+    if (filterValue === null) return false
+
+    if (
+      !(
+        (typeof itemValue === 'number' || typeof itemValue === 'string') &&
+        (typeof filterValue === 'number' || typeof filterValue === 'string')
+      )
+    ) {
+      throw new Error(
+        `Invalid comparison: ${JSON.stringify(itemValue)} and ${JSON.stringify(filterValue)} must be numbers or strings.`,
+      )
+    }
+
+    return comparators[opCode](itemValue, filterValue)
+  }
+
+  const eq =
+    itemValue === filterValue ||
+    (filterValue === null && itemValue === undefined) ||
+    (filterValue === 'null' && itemValue === null) ||
+    (filterValue === 'null' && itemValue === undefined) ||
+    (filterValue === 'true' && itemValue === true) ||
+    (filterValue === 'false' && itemValue === false)
+
+  return opCode === 'neq' ? !eq : eq
+}

--- a/src/Data/localStorageDataConnection.ts
+++ b/src/Data/localStorageDataConnection.ts
@@ -1,9 +1,9 @@
 import { DataConnection, DataConnectionResultItem } from 'scrivito'
 import { pseudoRandom32CharHex } from '../utils/pseudoRandom32CharHex'
-import { orderBy } from 'lodash-es'
 import { ensureString } from '../utils/ensureString'
 import { scrivitoTenantId } from '../config/scrivitoTenants'
 import { filterDataItems } from './filterDataItems'
+import { orderDataItems } from './orderDataItems'
 
 interface RawDataItem {
   _id: string
@@ -47,7 +47,7 @@ export function localStorageDataConnection(
           .some((value) => value.toLowerCase().includes(search)),
       )
 
-      const orderedItems = orderItems(matchingItems, params.order())
+      const orderedItems = orderDataItems(params.order(), matchingItems)
 
       const offset =
         params.continuation() === undefined ? 0 : Number(params.continuation())
@@ -186,17 +186,4 @@ function isRawDataItem(item: unknown): item is RawDataItem {
   if (!item) return false
   if (typeof item !== 'object') return false
   return typeof (item as RawDataItem)._id === 'string'
-}
-
-function orderItems(
-  items: DataConnectionResultItem[],
-  order: Array<[string, 'asc' | 'desc']>,
-): DataConnectionResultItem[] {
-  if (order.length === 0) return items
-
-  return orderBy(
-    items,
-    order.map(([attr]) => attr),
-    order.map(([_, ascOrDesc]) => ascOrDesc),
-  )
 }

--- a/src/Data/orderDataItems.ts
+++ b/src/Data/orderDataItems.ts
@@ -1,0 +1,15 @@
+import { orderBy } from 'lodash-es'
+import { DataConnectionResultItem } from 'scrivito'
+
+export function orderDataItems(
+  order: Array<[string, 'asc' | 'desc']>,
+  items: DataConnectionResultItem[],
+): DataConnectionResultItem[] {
+  if (order.length === 0) return items
+
+  return orderBy(
+    items,
+    order.map(([attr]) => attr),
+    order.map(([_, ascOrDesc]) => ascOrDesc),
+  )
+}


### PR DESCRIPTION
Discovered while using https://github.com/Scrivito/scrivito-portal-app/pull/752. Motivation: Show a "x active subscriptions" counter on the subscriptions page. This is only possible, if filters for subscriptions are supported.

While I was already at it, I supported most of the other options as well - or failed them on purpose.