### PR TITLE
Rerender <source> elements on change

### DIFF
--- a/src/Widgets/SectionWidget/SectionWidgetComponent.tsx
+++ b/src/Widgets/SectionWidget/SectionWidgetComponent.tsx
@@ -50,23 +50,46 @@ const ImageOrVideo = connect(function ImageOrVideo({
   const classNames = ['img-background']
   if (widget.get('backgroundAnimateOnHover')) classNames.push('img-zoom')
 
-  return (
-    // Check is a working around for issue #4767
-    // TODO: remove work around
-    background.contentType().startsWith('video/') &&
-      background.contentUrl().startsWith('https://') ? (
-      <video className={classNames.join(' ')} autoPlay loop muted playsInline>
-        <source src={background.contentUrl()} type={background.contentType()} />
-      </video>
-    ) : (
-      <InPlaceEditingOff>
-        <ImageTag
-          content={widget}
-          attribute="backgroundImage"
-          className={classNames.join(' ')}
-          alt=""
-        />
-      </InPlaceEditingOff>
+  if (background.contentType().startsWith('video/')) {
+    return (
+      <Video
+        className={classNames.join(' ')}
+        contentUrl={background.contentUrl()}
+        contentType={background.contentType()}
+        key={[
+          'SectionWidget',
+          widget.id(),
+          'Video',
+          background.contentUrl(),
+          background.contentType(),
+        ].join('-')} // Ensure the video is reloaded when the content changes
+      />
     )
+  }
+  return (
+    <InPlaceEditingOff>
+      <ImageTag
+        content={widget}
+        attribute="backgroundImage"
+        className={classNames.join(' ')}
+        alt=""
+      />
+    </InPlaceEditingOff>
+  )
+})
+
+const Video = connect(function Video({
+  className,
+  contentType,
+  contentUrl,
+}: {
+  className?: string
+  contentType: string
+  contentUrl: string
+}) {
+  return (
+    <video className={className} autoPlay loop muted playsInline>
+      <source src={contentUrl} type={contentType} />
+    </video>
   )
 })

--- a/src/Widgets/SectionWidget/SectionWidgetComponent.tsx
+++ b/src/Widgets/SectionWidget/SectionWidgetComponent.tsx
@@ -52,20 +52,18 @@ const ImageOrVideo = connect(function ImageOrVideo({
 
   if (background.contentType().startsWith('video/')) {
     return (
-      <Video
+      <video
+        autoPlay
         className={classNames.join(' ')}
-        contentUrl={background.contentUrl()}
-        contentType={background.contentType()}
-        key={[
-          'SectionWidget',
-          widget.id(),
-          'Video',
-          background.contentUrl(),
-          background.contentType(),
-        ].join('-')} // Ensure the video is reloaded when the content changes
+        key={background.contentUrl()}
+        loop
+        muted
+        playsInline
+        src={background.contentUrl()}
       />
     )
   }
+
   return (
     <InPlaceEditingOff>
       <ImageTag
@@ -75,21 +73,5 @@ const ImageOrVideo = connect(function ImageOrVideo({
         alt=""
       />
     </InPlaceEditingOff>
-  )
-})
-
-const Video = connect(function Video({
-  className,
-  contentType,
-  contentUrl,
-}: {
-  className?: string
-  contentType: string
-  contentUrl: string
-}) {
-  return (
-    <video className={className} autoPlay loop muted playsInline>
-      <source src={contentUrl} type={contentType} />
-    </video>
   )
 })

--- a/src/Widgets/SliderWidget/SliderWidgetComponent.tsx
+++ b/src/Widgets/SliderWidget/SliderWidgetComponent.tsx
@@ -55,16 +55,14 @@ const ImageOrVideo = connect(function ImageOrVideo({
 
   if (background.contentType().startsWith('video/')) {
     return (
-      <Video
-        contentUrl={background.contentUrl()}
-        contentType={background.contentType()}
-        key={[
-          'SliderWidget',
-          widget.id(),
-          'Video',
-          background.contentUrl(),
-          background.contentType(),
-        ].join('-')} // Ensure the video is reloaded when the content changes
+      <video
+        autoPlay
+        className="img-background"
+        key={background.contentUrl()}
+        loop
+        muted
+        playsInline
+        src={background.contentUrl()}
       />
     )
   }
@@ -78,19 +76,5 @@ const ImageOrVideo = connect(function ImageOrVideo({
         className="img-background"
       />
     </InPlaceEditingOff>
-  )
-})
-
-const Video = connect(function Video({
-  contentType,
-  contentUrl,
-}: {
-  contentType: string
-  contentUrl: string
-}) {
-  return (
-    <video autoPlay loop muted playsInline className="img-background">
-      <source src={contentUrl} type={contentType} />
-    </video>
   )
 })

--- a/src/Widgets/SliderWidget/SliderWidgetComponent.tsx
+++ b/src/Widgets/SliderWidget/SliderWidgetComponent.tsx
@@ -45,32 +45,52 @@ provideComponent(SliderWidget, ({ widget }) => {
   )
 })
 
-const ImageOrVideo = connect(
-  function ImageOrVideo({ widget }: { widget: SlideWidgetInstance }) {
-    const background = widget.get('background')
-    if (!background) return null
+const ImageOrVideo = connect(function ImageOrVideo({
+  widget,
+}: {
+  widget: SlideWidgetInstance
+}) {
+  const background = widget.get('background')
+  if (!background) return null
 
-    if (background.contentType().startsWith('video/')) {
-      return (
-        <video autoPlay loop muted playsInline className="img-background">
-          <source
-            src={background.contentUrl()}
-            type={background.contentType()}
-          />
-        </video>
-      )
-    }
-
+  if (background.contentType().startsWith('video/')) {
     return (
-      <InPlaceEditingOff>
-        <ImageTag
-          content={widget}
-          attribute="background"
-          alt=""
-          className="img-background"
-        />
-      </InPlaceEditingOff>
+      <Video
+        contentUrl={background.contentUrl()}
+        contentType={background.contentType()}
+        key={[
+          'SliderWidget',
+          widget.id(),
+          'Video',
+          background.contentUrl(),
+          background.contentType(),
+        ].join('-')} // Ensure the video is reloaded when the content changes
+      />
     )
-  },
-  { loading: () => null },
-)
+  }
+
+  return (
+    <InPlaceEditingOff>
+      <ImageTag
+        content={widget}
+        attribute="background"
+        alt=""
+        className="img-background"
+      />
+    </InPlaceEditingOff>
+  )
+})
+
+const Video = connect(function Video({
+  contentType,
+  contentUrl,
+}: {
+  contentType: string
+  contentUrl: string
+}) {
+  return (
+    <video autoPlay loop muted playsInline className="img-background">
+      <source src={contentUrl} type={contentType} />
+    </video>
+  )
+})


### PR DESCRIPTION
Fixes #767.

As far as I can see, if one changes the `src` of the `<source>` dom element, the browser (at least Chromium) will ignore this `<source>` and pretend that it does not exist.

With the explicit `key` we tell React to recreate a new `<video>` dom element, if the content URL or it type changes.

It is also a better solution for #4767 (in Scrivito)