### PR TITLE
Dropdown: Show 404 instead of redirect

### DIFF
--- a/src/Objs/Dropdown/DropdownComponent.tsx
+++ b/src/Objs/Dropdown/DropdownComponent.tsx
@@ -1,26 +1,7 @@
-import { provideComponent, isEditorLoggedIn, load, Obj, urlFor } from 'scrivito'
+import { provideComponent, isEditorLoggedIn, Obj, ContentTag } from 'scrivito'
 import { Dropdown } from './DropdownObjClass'
-import { useEffect } from 'react'
 
-provideComponent(Dropdown, ({ page }) => {
-  useEffect(() => {
-    navigateAway()
-
-    async function navigateAway() {
-      if (isEditorLoggedIn()) return
-
-      const destination =
-        (await load(() => page.orderedChildren()[0])) ||
-        (await load(() => page.parent())) ||
-        (await load(() => Obj.root()))
-
-      if (!destination) return
-
-      const url = await load(() => urlFor(destination))
-      window.location.replace(url)
-    }
-  }, [page])
-
+provideComponent(Dropdown, () => {
   if (isEditorLoggedIn()) {
     return (
       <main id="main">
@@ -40,5 +21,12 @@ provideComponent(Dropdown, ({ page }) => {
     )
   }
 
-  return null
+  return (
+    <ContentTag
+      tag="main"
+      id="main"
+      content={Obj.root()}
+      attribute="siteNotFound"
+    />
+  )
 })

--- a/src/Objs/Dropdown/DropdownObjClass.ts
+++ b/src/Objs/Dropdown/DropdownObjClass.ts
@@ -7,3 +7,9 @@ export const Dropdown = provideObjClass('Dropdown', {
     title: 'string',
   },
 })
+
+export type DropdownInstance = InstanceType<typeof Dropdown>
+
+export function isDropdown(input: unknown): input is DropdownInstance {
+  return input instanceof Dropdown
+}

--- a/src/utils/getMetadata.ts
+++ b/src/utils/getMetadata.ts
@@ -2,8 +2,11 @@ import { Obj, urlFor, extractText } from 'scrivito'
 import { truncate } from 'lodash-es'
 import { ensureString } from './ensureString'
 import { isImage } from '../Objs/Image/ImageObjClass'
+import { isDropdown } from '../Objs/Dropdown/DropdownObjClass'
 
 export function getMetadata(page: Obj) {
+  if (isDropdown(page)) return [{ name: 'robots', content: 'noindex' }]
+
   const meta = [
     { name: 'twitter:card', content: 'summary_large_image' },
     { property: 'og:type', content: 'article' },


### PR DESCRIPTION
Only for regular visitors, not editors.

Motivation: Don't train users that the auto-redirect URLs work.