### PR TITLE
SectionWidget: !showPadding => no padding

### DIFF
--- a/src/Widgets/BreadcrumbWidget/BreadcrumbWidgetComponent.tsx
+++ b/src/Widgets/BreadcrumbWidget/BreadcrumbWidgetComponent.tsx
@@ -11,7 +11,7 @@ provideComponent(BreadcrumbWidget, () => {
     .filter((item): item is Obj => !!item && !item.get('hideInNavigation'))
 
   return (
-    <nav aria-label="breadcrumb">
+    <nav aria-label="breadcrumb" className="py-2">
       <ol className="breadcrumb m-1">
         {breadcrumbItems.map((obj) => (
           <li className="breadcrumb-item" key={obj.id()}>

--- a/src/Widgets/SectionWidget/SectionWidgetComponent.tsx
+++ b/src/Widgets/SectionWidget/SectionWidgetComponent.tsx
@@ -16,7 +16,7 @@ provideComponent(SectionWidget, ({ widget }) => {
     sectionClassNames.push(`bg-${backgroundColor}`)
   }
 
-  sectionClassNames.push(widget.get('showPadding') ? 'py-5' : 'py-2')
+  if (widget.get('showPadding')) sectionClassNames.push('py-5')
 
   let contentClassName = 'container'
   if (widget.get('containerWidth') === '95-percent') {


### PR DESCRIPTION
Needs content: https://edit.scrivito.com/d0a154d76edf2a7bd991fc658e700a1d~https://section-real-no-padding.scrivito-portal-app.pages.dev/en?_scrivito_workspace_id=i9e9de05e0394f78&_scrivito_display_mode=diff

Previously some padding was added, but is now in the way, e.g. for modern landing pages.