### PR TITLE
metaDataDescription => description

### DIFF
--- a/src/Data/ContentSearchResult/ContentSearchResultDataClass.ts
+++ b/src/Data/ContentSearchResult/ContentSearchResultDataClass.ts
@@ -73,8 +73,7 @@ function objToResult(obj: Obj) {
   const imageId = isImage(imageReference) ? imageReference.id() : null
 
   const snippet =
-    ensureString(obj.get('metaDataDescription')) ||
-    extractText(obj, { length: 300 })
+    ensureString(obj.get('description')) || extractText(obj, { length: 300 })
 
   return {
     _id: obj.id(),

--- a/src/Objs/ProductCategory/ProductCategoryEditingConfig.ts
+++ b/src/Objs/ProductCategory/ProductCategoryEditingConfig.ts
@@ -13,7 +13,7 @@ provideEditingConfig(ProductCategory, {
   title: 'Product Category',
   thumbnail: Thumbnail,
   attributes: defaultPageEditingConfigAttributes,
-  properties: [...defaultPageProperties, 'description', 'image'],
+  properties: [...defaultPageProperties, 'image'],
   propertiesGroups: defaultPagePropertiesGroups,
   thumbnailForContent: (obj) => obj.get('image'),
   initialContent: defaultPageInitialContent,

--- a/src/Objs/ProductCategory/ProductCategoryObjClass.ts
+++ b/src/Objs/ProductCategory/ProductCategoryObjClass.ts
@@ -4,7 +4,6 @@ import { defaultPageAttributes } from '../defaultPageAttributes'
 export const ProductCategory = provideObjClass('ProductCategory', {
   attributes: {
     ...defaultPageAttributes,
-    description: 'string',
     image: ['reference', { only: ['Image'] }],
   },
   extractTextAttributes: ['description'],

--- a/src/Objs/defaultPageAttributes.ts
+++ b/src/Objs/defaultPageAttributes.ts
@@ -32,6 +32,7 @@ export const defaultPageAttributes = {
     },
   ],
   // Meta tags
+  description: 'string',
   metaDataDescription: 'string',
   robotsIndex: 'boolean',
   // Twitter attributes

--- a/src/Objs/defaultPageAttributes.ts
+++ b/src/Objs/defaultPageAttributes.ts
@@ -33,7 +33,6 @@ export const defaultPageAttributes = {
   ],
   // Meta tags
   description: 'string',
-  metaDataDescription: 'string',
   robotsIndex: 'boolean',
   // Twitter attributes
   tcCreator: 'string',

--- a/src/Objs/defaultPageEditingConfig.tsx
+++ b/src/Objs/defaultPageEditingConfig.tsx
@@ -8,6 +8,10 @@ export const defaultPageEditingConfigAttributes = {
     title: 'Title',
     description: 'Limit to 55 characters.',
   },
+  description: {
+    title: 'Page description',
+    description: 'Limit to 175, ideally 150 characters.',
+  },
   metaDataDescription: {
     title: 'Page description',
     description: 'Limit to 175, ideally 150 characters.',
@@ -88,7 +92,7 @@ export const defaultPagePropertiesGroups = [
   },
   {
     title: 'Metadata',
-    properties: ['metaDataDescription', 'robotsIndex'],
+    properties: ['description', 'metaDataDescription', 'robotsIndex'],
     key: 'metadata-group',
   },
   {
@@ -117,6 +121,18 @@ export const defaultPageValidations = [
       if (ensureString(title).length === 0) {
         return {
           message: 'The title should be set.',
+          severity: 'warning',
+        }
+      }
+    },
+  ],
+  [
+    'description',
+
+    (description: unknown) => {
+      if (ensureString(description).length > 175) {
+        return {
+          message: 'The page description should not exceed 175 characters.',
           severity: 'warning',
         }
       }

--- a/src/Objs/defaultPageEditingConfig.tsx
+++ b/src/Objs/defaultPageEditingConfig.tsx
@@ -12,10 +12,6 @@ export const defaultPageEditingConfigAttributes = {
     title: 'Page description',
     description: 'Limit to 175, ideally 150 characters.',
   },
-  metaDataDescription: {
-    title: 'Page description',
-    description: 'Limit to 175, ideally 150 characters.',
-  },
   robotsIndex: {
     title: 'Should this page be indexed?',
     description: 'If not, search engines will ignore this page. Default: Yes',
@@ -92,7 +88,7 @@ export const defaultPagePropertiesGroups = [
   },
   {
     title: 'Metadata',
-    properties: ['description', 'metaDataDescription', 'robotsIndex'],
+    properties: ['description', 'robotsIndex'],
     key: 'metadata-group',
   },
   {
@@ -131,18 +127,6 @@ export const defaultPageValidations = [
 
     (description: unknown) => {
       if (ensureString(description).length > 175) {
-        return {
-          message: 'The page description should not exceed 175 characters.',
-          severity: 'warning',
-        }
-      }
-    },
-  ],
-  [
-    'metaDataDescription',
-
-    (metaDataDescription: unknown) => {
-      if (ensureString(metaDataDescription).length > 175) {
         return {
           message: 'The page description should not exceed 175 characters.',
           severity: 'warning',

--- a/src/Widgets/SearchResultsWidget/SearchResult.tsx
+++ b/src/Widgets/SearchResultsWidget/SearchResult.tsx
@@ -69,7 +69,7 @@ const TextDescription = connect(function TextResult({
   const searchWords = query.split(/\s+/)
 
   const description =
-    ensureString(searchResult.get('metaDataDescription')) ||
+    ensureString(searchResult.get('description')) ||
     extractText(searchResult, { length: 300 })
 
   const shortDescription = truncate(useResolvedStringValue(description), {

--- a/src/utils/getMetadata.ts
+++ b/src/utils/getMetadata.ts
@@ -18,7 +18,7 @@ export function getMetadata(page: Obj) {
     meta.push({ name: 'robots', content: 'noindex' })
   }
 
-  const description = ensureString(page.get('metaDataDescription'))
+  const description = ensureString(page.get('description'))
   if (description) {
     meta.push({ name: 'description', content: description })
   }


### PR DESCRIPTION
`metaDataDescription` was originally introduced in https://github.com/Scrivito/scrivito_example_app_js/commit/a9f29d18b011be82630bd8c7e55ebb18f517f370#diff-6f02b4692074b5c3984b8d01f9bc00693e47e6185df112d8e5524dcc6e8420a9R3. But the name is quite old and can be simplified. Requested by Kris. Since there are not many places, that use `metaDataDescription` I think this is a good request.

Needs content: https://edit.scrivito.com/d0a154d76edf2a7bd991fc658e700a1d~https://rip-meta-data-description.scrivito-portal-app.pages.dev/en/my-profile?_scrivito_workspace_id=ubbd3298f18c6b0f&_scrivito_display_mode=diff