### PR TITLE
Gdpr: tokenAuthorization based supports search, count and order

### DIFF
--- a/src/Data/Gdpr/GdprDataClass.ts
+++ b/src/Data/Gdpr/GdprDataClass.ts
@@ -26,25 +26,24 @@ export const Gdpr = provideDataClass(
                 )
               }
 
-              if (params.order().length > 0) {
-                throw new DataConnectionError(
-                  'GDPR consent does not support sorting.',
-                )
-              }
-
-              if (params.search()) {
-                throw new DataConnectionError(
-                  'GDPR consent does not support searching.',
-                )
-              }
-
               const urlParams = new URLSearchParams()
+
+              const continuation = params.continuation()
+              if (continuation) urlParams.set('_continuation', continuation)
+
+              if (params.includeCount()) urlParams.set('_count', 'true')
 
               const limit = params.limit()
               if (limit) urlParams.set('_limit', limit.toString())
 
-              const continuation = params.continuation()
-              if (continuation) urlParams.set('_continuation', continuation)
+              const order = params
+                .order()
+                .map((o) => o.join('.'))
+                .join(',')
+              if (order) urlParams.set('_order', order)
+
+              const search = params.search()
+              if (search) urlParams.set('_search', search)
 
               const urlWithParams = `${url}?${urlParams.toString()}`
 


### PR DESCRIPTION
Filter is too complex to implement, but the rest is mostly "pass on".

Needs content: https://edit.scrivito.com/d0a154d76edf2a7bd991fc658e700a1d~https://gdpr-support-sorting.scrivito-portal-app.pages.dev/en/gdpr-consent-form?_scrivito_workspace_id=qb34eb88398ae576&_scrivito_display_mode=view