### PR TITLE
WrongContentFormat: Improve error message

### DIFF
--- a/src/privateJrPlatform/Components/WrongContentFormat.tsx
+++ b/src/privateJrPlatform/Components/WrongContentFormat.tsx
@@ -4,6 +4,8 @@ import errorBackground from '../../assets/images/error-background.jpg'
 import spaceman from '../../assets/images/spaceman.svg'
 
 export const WrongContentFormat = connect(function WrongContentFormat() {
+  const contentFormat = ensureString(Obj.root()?.get('contentFormat'))
+
   return (
     <main id="main">
       <section className="bg-danger vh-100 py-5">
@@ -20,8 +22,9 @@ export const WrongContentFormat = connect(function WrongContentFormat() {
             <div className="col-sm-6">
               <h1 className="display-1">Error</h1>
               <h3 className="h3">
-                Content format “{ensureString(Obj.root()?.get('contentFormat'))}
-                ” not supported.
+                {contentFormat
+                  ? `Content format “${contentFormat}” is unsupported.`
+                  : 'Missing content format.'}
               </h3>
             </div>
           </div>


### PR DESCRIPTION
Improved message e.g. for tenant `9d40fdf1b7bce0f07d83086580be796d`.