### PR TITLE
Avoid white background when scrolling different-height slides

### DIFF
--- a/src/Widgets/SliderWidget/SliderWidget.scss
+++ b/src/Widgets/SliderWidget/SliderWidget.scss
@@ -1,6 +1,10 @@
 .slider-widget {
   --jr-border-radius: 0;
 
+  .carousel-inner {
+    display: flex;
+  }
+
   .carousel-item {
     border-radius: 0;
     overflow: hidden;


### PR DESCRIPTION
### Before

<img width="918" alt="image" src="https://github.com/user-attachments/assets/26990a9d-ef55-49d3-8c92-497acccc93d8" />


### After

<img width="918" alt="image" src="https://github.com/user-attachments/assets/1fd30f93-43c3-4332-a382-54aac744fea5" />
