### PR TITLE
Make all language icons equal width

### DIFF
--- a/src/assets/stylesheets/index.scss
+++ b/src/assets/stylesheets/index.scss
@@ -859,9 +859,9 @@ section .card.no-color-adaption {
 
 img.img-flag {
   display: inline-block;
-  height: 15px;
   margin: -3px 6px 0 0;
-  max-width: 17px;
+  max-height: 15px;
+  width: 17px;
 }
 
 /* Bootstrap Icons - Sizes Add-on

--- a/src/assets/stylesheets/scrivitoEditing.scss
+++ b/src/assets/stylesheets/scrivitoEditing.scss
@@ -6,7 +6,9 @@
   text-transform: none;
 }
 
+// TODO: Remove workaround for issue #11731
 .img-flag[data-scrivito-image-placeholder] {
   min-height: unset !important;
+  opacity: 0 !important;
   width: 17px !important;
 }

--- a/src/assets/stylesheets/scrivitoEditing.scss
+++ b/src/assets/stylesheets/scrivitoEditing.scss
@@ -5,3 +5,8 @@
 [contenteditable]:focus-within {
   text-transform: none;
 }
+
+.img-flag[data-scrivito-image-placeholder] {
+  min-height: unset !important;
+  width: 17px !important;
+}


### PR DESCRIPTION
This avoids uneven text alignment and loading alignment flashes

### Before

![image](https://github.com/user-attachments/assets/60094ca6-aca1-4c60-adc6-e635a0b2fd7a)


### After

<img src="https://github.com/user-attachments/assets/45c84bd6-157e-46a4-8587-48be597edc1a" />
