### PR TITLE
Data form widgets: Add validation, that the widget is part of a data …

### DIFF
--- a/src/Widgets/DataFormBooleanWidget/DataFormBooleanWidgetEditingConfig.ts
+++ b/src/Widgets/DataFormBooleanWidget/DataFormBooleanWidgetEditingConfig.ts
@@ -1,6 +1,7 @@
 import { provideEditingConfig } from 'scrivito'
 import { DataFormBooleanWidget } from './DataFormBooleanWidgetClass'
 import Thumbnail from './thumbnail.svg'
+import { insideDataFormContainerValidation } from '../DataFormContainerWidget/insideDataFormContainerValidation'
 
 provideEditingConfig(DataFormBooleanWidget, {
   title: 'Data Form Boolean',
@@ -50,4 +51,5 @@ provideEditingConfig(DataFormBooleanWidget, {
     onLabel: 'On',
     style: 'check',
   },
+  validations: [insideDataFormContainerValidation],
 })

--- a/src/Widgets/DataFormContainerWidget/insideDataFormContainerValidation.ts
+++ b/src/Widgets/DataFormContainerWidget/insideDataFormContainerValidation.ts
@@ -1,0 +1,16 @@
+import { Widget } from 'scrivito'
+
+export function insideDataFormContainerValidation(widget: Widget) {
+  if (!getDataFormContainer(widget)) return 'Needs to be inside a data form.'
+}
+
+function getDataFormContainer(childWidget: Widget): Widget | null {
+  let candidate = childWidget.container()
+  while (candidate instanceof Widget) {
+    if (candidate.objClass() === 'DataFormContainerWidget') return candidate
+
+    candidate = candidate.container()
+  }
+
+  return null
+}

--- a/src/Widgets/DataFormInputFieldWidget/DataFormInputFieldWidgetEditingConfig.ts
+++ b/src/Widgets/DataFormInputFieldWidget/DataFormInputFieldWidgetEditingConfig.ts
@@ -1,6 +1,7 @@
 import { provideEditingConfig } from 'scrivito'
 import { DataFormInputFieldWidget } from './DataFormInputFieldWidgetClass'
 import Thumbnail from './thumbnail.svg'
+import { insideDataFormContainerValidation } from '../DataFormContainerWidget/insideDataFormContainerValidation'
 
 provideEditingConfig(DataFormInputFieldWidget, {
   title: 'Data Form Input Field',
@@ -36,4 +37,5 @@ provideEditingConfig(DataFormInputFieldWidget, {
     label: 'Custom field',
     type: 'single_line',
   },
+  validations: [insideDataFormContainerValidation],
 })

--- a/src/Widgets/DataFormNumberWidget/DataFormNumberWidgetEditingConfig.tsx
+++ b/src/Widgets/DataFormNumberWidget/DataFormNumberWidgetEditingConfig.tsx
@@ -1,6 +1,7 @@
 import { provideEditingConfig } from 'scrivito'
 import Thumbnail from './thumbnail.svg'
 import { DataFormNumberWidget } from './DataFormNumberWidgetClass'
+import { insideDataFormContainerValidation } from '../DataFormContainerWidget/insideDataFormContainerValidation'
 
 provideEditingConfig(DataFormNumberWidget, {
   title: 'Data Form Number',
@@ -38,4 +39,5 @@ provideEditingConfig(DataFormNumberWidget, {
     minValue: 0,
     stepValue: 1.0,
   },
+  validations: [insideDataFormContainerValidation],
 })

--- a/src/Widgets/DataFormOptionsWidget/DataFormOptionsWidgetEditingConfig.ts
+++ b/src/Widgets/DataFormOptionsWidget/DataFormOptionsWidgetEditingConfig.ts
@@ -1,6 +1,7 @@
 import { provideEditingConfig } from 'scrivito'
 import { DataFormOptionsWidget } from './DataFormOptionsWidgetClass'
 import Thumbnail from './thumbnail.svg'
+import { insideDataFormContainerValidation } from '../DataFormContainerWidget/insideDataFormContainerValidation'
 
 provideEditingConfig(DataFormOptionsWidget, {
   title: 'Data Form Options',
@@ -25,4 +26,5 @@ provideEditingConfig(DataFormOptionsWidget, {
   initialContent: {
     label: 'Custom field',
   },
+  validations: [insideDataFormContainerValidation],
 })

--- a/src/Widgets/DataFormSubmitButtonWidget/DataFormSubmitButtonWidgetEditingConfig.ts
+++ b/src/Widgets/DataFormSubmitButtonWidget/DataFormSubmitButtonWidgetEditingConfig.ts
@@ -1,6 +1,7 @@
 import { provideEditingConfig } from 'scrivito'
 import { DataFormSubmitButtonWidget } from './DataFormSubmitButtonWidgetClass'
 import Thumbnail from './thumbnail.svg'
+import { insideDataFormContainerValidation } from '../DataFormContainerWidget/insideDataFormContainerValidation'
 
 provideEditingConfig(DataFormSubmitButtonWidget, {
   title: 'Data Form Submit Button',
@@ -50,4 +51,6 @@ provideEditingConfig(DataFormSubmitButtonWidget, {
     alignment: 'left',
     size: 'medium',
   },
+
+  validations: [insideDataFormContainerValidation],
 })

--- a/src/Widgets/DataFormUploadWidget/DataFormUploadWidgetEditingConfig.ts
+++ b/src/Widgets/DataFormUploadWidget/DataFormUploadWidgetEditingConfig.ts
@@ -1,6 +1,7 @@
 import { provideEditingConfig } from 'scrivito'
 import { DataFormUploadWidget } from './DataFormUploadWidgetClass'
 import Thumbnail from './thumbnail.svg'
+import { insideDataFormContainerValidation } from '../DataFormContainerWidget/insideDataFormContainerValidation'
 
 provideEditingConfig(DataFormUploadWidget, {
   title: 'Data Form Upload',
@@ -20,4 +21,5 @@ provideEditingConfig(DataFormUploadWidget, {
   initialContent: {
     label: 'File',
   },
+  validations: [insideDataFormContainerValidation],
 })


### PR DESCRIPTION
…form container

Otherwise the widget will look like "all is good", where as no data is update/created.

Inspired by https://github.com/Scrivito/scrivito_example_app_js/blob/master/src/Widgets/FormContainerWidget/utils/validations/insideFormContainerValidation.js