### PR TITLE
[npm] Downgrade @vitejs/plugin-react-swc

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,7 @@
         "@types/speakingurl": "^13.0.6",
         "@typescript-eslint/eslint-plugin": "^8.31.1",
         "@typescript-eslint/parser": "^8.31.1",
-        "@vitejs/plugin-react-swc": "^3.9.0",
+        "@vitejs/plugin-react-swc": "^3.8.1",
         "bootstrap-icons": "^1.12.1",
         "content-security-policy-builder": "^2.3.0",
         "eslint": "^9.26.0",
@@ -2453,13 +2453,13 @@
       }
     },
     "node_modules/@vitejs/plugin-react-swc": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react-swc/-/plugin-react-swc-3.9.0.tgz",
-      "integrity": "sha512-jYFUSXhwMCYsh/aQTgSGLIN3Foz5wMbH9ahb0Zva//UzwZYbMiZd7oT3AU9jHT9DLswYDswsRwPU9jVF3yA48Q==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react-swc/-/plugin-react-swc-3.8.1.tgz",
+      "integrity": "sha512-aEUPCckHDcFyxpwFm0AIkbtv6PpUp3xTb9wYGFjtABynXjCYKkWoxX0AOK9NT9XCrdk6mBBUOeHQS+RKdcNO1A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@swc/core": "^1.11.21"
+        "@swc/core": "^1.11.11"
       },
       "peerDependencies": {
         "vite": "^4 || ^5 || ^6"

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "@types/speakingurl": "^13.0.6",
     "@typescript-eslint/eslint-plugin": "^8.31.1",
     "@typescript-eslint/parser": "^8.31.1",
-    "@vitejs/plugin-react-swc": "^3.9.0",
+    "@vitejs/plugin-react-swc": "^3.8.1",
     "bootstrap-icons": "^1.12.1",
     "content-security-policy-builder": "^2.3.0",
     "eslint": "^9.26.0",


### PR DESCRIPTION
The newer version broke local development. It's not yet clear, why. Downgrading for now.