### PR TITLE
"unknown" attributes

### DIFF
--- a/src/Data/Document/DocumentEditingConfig.ts
+++ b/src/Data/Document/DocumentEditingConfig.ts
@@ -1,8 +1,0 @@
-import { provideEditingConfig } from 'scrivito'
-import { Document } from './DocumentDataClass'
-
-provideEditingConfig(Document, {
-  attributes: {
-    body: { title: 'Body' },
-  },
-})

--- a/src/Data/Document/documentParamsFallback.ts
+++ b/src/Data/Document/documentParamsFallback.ts
@@ -158,6 +158,10 @@ async function attributes(): Promise<DataAttributeDefinitions> {
   ] as const
 
   return {
+    body: [
+      'unknown',
+      { title: lang === 'de' ? 'Körper' : 'Body', type: 'X-Pisa-Binary' },
+    ],
     createdAt: ['date', { title: lang === 'de' ? 'Erzeugt am' : 'Created at' }],
     format: [
       'string',

--- a/src/Data/Event/EventEditingConfig.ts
+++ b/src/Data/Event/EventEditingConfig.ts
@@ -1,8 +1,0 @@
-import { provideEditingConfig } from 'scrivito'
-import { Event } from './EventDataClass'
-
-provideEditingConfig(Event, {
-  attributes: {
-    logo: { title: 'Logo' },
-  },
-})

--- a/src/Data/Event/eventParamsFallback.ts
+++ b/src/Data/Event/eventParamsFallback.ts
@@ -84,6 +84,7 @@ async function attributes(): Promise<DataAttributeDefinitions> {
     keyword: ['string', { title: lang === 'de' ? 'Stichwort' : 'Keyword' }],
     language,
     location: ['string', { title: lang === 'de' ? 'Ort' : 'Location' }],
+    logo: ['unknown', { title: 'Logo', type: 'X-Pisa-Binary' }],
     number: ['string', { title: lang === 'de' ? 'Nummer' : 'Number' }],
     organizer: [
       'string',

--- a/src/Data/Message/MessageEditingConfig.ts
+++ b/src/Data/Message/MessageEditingConfig.ts
@@ -1,8 +1,0 @@
-import { provideEditingConfig } from 'scrivito'
-import { Message } from './MessageDataClass'
-
-provideEditingConfig(Message, {
-  attributes: {
-    subjectId: { title: 'Subject ID' },
-  },
-})

--- a/src/Data/Message/MessageEditingConfig.ts
+++ b/src/Data/Message/MessageEditingConfig.ts
@@ -3,7 +3,6 @@ import { Message } from './MessageDataClass'
 
 provideEditingConfig(Message, {
   attributes: {
-    attachments: { title: 'Attachments' },
     subjectId: { title: 'Subject ID' },
   },
 })

--- a/src/Data/Message/messageParamsFallback.ts
+++ b/src/Data/Message/messageParamsFallback.ts
@@ -5,6 +5,13 @@ async function attributes(): Promise<DataAttributeDefinitions> {
   const lang = await load(currentLanguage)
 
   return {
+    attachments: [
+      'unknown',
+      {
+        title: lang === 'de' ? 'Anhänge' : 'Attachments',
+        type: 'X-Pisa-Binary[]',
+      },
+    ],
     createdAt: ['string', { title: lang === 'de' ? 'Gesendet am' : 'Sent at' }],
     createdBy: [
       'reference',

--- a/src/Data/Message/messageParamsFallback.ts
+++ b/src/Data/Message/messageParamsFallback.ts
@@ -20,6 +20,14 @@ async function attributes(): Promise<DataAttributeDefinitions> {
         to: 'User',
       },
     ],
+    subjectId: [
+      // TODO: Remove once #11410 is solved.
+      'unknown',
+      {
+        title: lang === 'de' ? 'Betreff' : 'Subject',
+        type: 'X-Pisa-Polymorphic-Reference',
+      },
+    ],
     text: ['string', { title: 'Text' }],
   }
 }

--- a/src/Data/ServiceObject/ServiceObjectEditingConfig.ts
+++ b/src/Data/ServiceObject/ServiceObjectEditingConfig.ts
@@ -1,8 +1,0 @@
-import { provideEditingConfig } from 'scrivito'
-import { ServiceObject } from './ServiceObjectDataClass'
-
-provideEditingConfig(ServiceObject, {
-  attributes: {
-    picture: { title: 'Picture' },
-  },
-})

--- a/src/Data/ServiceObject/serviceObjectParamsFallback.ts
+++ b/src/Data/ServiceObject/serviceObjectParamsFallback.ts
@@ -733,6 +733,10 @@ async function attributes(): Promise<DataAttributeDefinitions> {
         to: 'ServiceObject',
       },
     ],
+    picture: [
+      'unknown',
+      { title: lang === 'de' ? 'Bild' : 'Picture', type: 'X-Pisa-Binary' },
+    ],
     product: [
       'string',
       { title: lang === 'de' ? 'Produktname' : 'Product name' },

--- a/src/Data/Ticket/TicketEditingConfig.ts
+++ b/src/Data/Ticket/TicketEditingConfig.ts
@@ -1,8 +1,0 @@
-import { provideEditingConfig } from 'scrivito'
-import { Ticket } from './TicketDataClass'
-
-provideEditingConfig(Ticket, {
-  attributes: {
-    attachments: { title: 'Attachments' },
-  },
-})

--- a/src/Data/Ticket/ticketParamsFallback.ts
+++ b/src/Data/Ticket/ticketParamsFallback.ts
@@ -123,6 +123,13 @@ async function attributes(): Promise<DataAttributeDefinitions> {
   ] as const
 
   return {
+    attachments: [
+      'unknown',
+      {
+        title: lang === 'de' ? 'Anhänge' : 'Attachments',
+        type: 'X-Pisa-Binary[]',
+      },
+    ],
     createdAt: ['date', { title: lang === 'de' ? 'Erzeugt am' : 'Created at' }],
     createdBy: [
       'reference',

--- a/src/Data/User/UserEditingConfig.ts
+++ b/src/Data/User/UserEditingConfig.ts
@@ -1,8 +1,0 @@
-import { provideEditingConfig } from 'scrivito'
-import { User } from './UserDataClass'
-
-provideEditingConfig(User, {
-  attributes: {
-    image: { title: 'Image' },
-  },
-})

--- a/src/Data/User/userParamsFallback.ts
+++ b/src/Data/User/userParamsFallback.ts
@@ -54,6 +54,10 @@ async function attributes(): Promise<DataAttributeDefinitions> {
       { title: lang === 'de' ? 'Nachname' : 'Family name' },
     ],
     givenName: ['string', { title: lang === 'de' ? 'Vorname' : 'Given name' }],
+    image: [
+      'unknown',
+      { title: lang === 'de' ? 'Bild' : 'Image', type: 'X-Pisa-Binary' },
+    ],
     name: ['string', { title: 'Name' }],
     position: ['string', { title: 'Position' }],
     salutation,


### PR DESCRIPTION
⚠️Please do not merge this PR yet⚠️

This PR:
* Declares all binary attributes as `X-Pisa-Binary`.
* Declares all `attachments` as `X-Pisa-Binary[]`.
* Declares `subjectId` of a `Message` as `X-Pisa-Polymorphic-Reference`.

Translations of attribute names are done by me and can probably be improved.