### PR TITLE
DataImageWidget: Tread empty strings as empty images

### DIFF
--- a/src/Widgets/DataImageWidget/DataImageWidgetComponent.tsx
+++ b/src/Widgets/DataImageWidget/DataImageWidgetComponent.tsx
@@ -100,6 +100,7 @@ const ImageComponent = connect(function ImageComponent({
   }
 
   if (typeof attributeValue !== 'string') return null
+  if (!attributeValue) return null
 
   return <img src={attributeValue} className={className} style={style} alt="" />
 })


### PR DESCRIPTION
This can be the case, if e.g. a data attribute is defined as "string", but has no URL. In that case the SDK will always return a string (an empty string in this case).