### PR TITLE
Include Honeybadger right away

### DIFF
--- a/.knip.jsonc
+++ b/.knip.jsonc
@@ -12,6 +12,7 @@
   ],
   "ignore": [
     "src/Data/localStorageDataConnection.ts", // TODO: Remove from knip, once searchLocalStorageDataConnections is in use
+    "src/honeybadgerStub.ts",
     "public/scrivito/**",
     "src/assets/stylesheets/vendor/**",
     "vendor/**",

--- a/src/config/configureErrorReporting.ts
+++ b/src/config/configureErrorReporting.ts
@@ -5,11 +5,10 @@ import {
   load,
   Obj,
 } from 'scrivito'
+import Honeybadger from '@honeybadger-io/js'
 
 export async function configureErrorReporting() {
   if (!import.meta.env.HONEYBADGER_API_KEY) return
-
-  const { default: Honeybadger } = await import('@honeybadger-io/js')
 
   const honeybadger = Honeybadger.configure({
     apiKey: import.meta.env.HONEYBADGER_API_KEY,

--- a/src/honeybadgerStub.ts
+++ b/src/honeybadgerStub.ts
@@ -1,0 +1,9 @@
+// Stub implementation for Honeybadger when API key is not available
+const Honeybadger = {
+  configure: () => ({
+    setContext: () => {},
+    notify: () => {},
+  }),
+}
+
+export default Honeybadger

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -57,6 +57,13 @@ export default defineConfig(({ mode }) => {
       },
       sourcemap: !!HONEYBADGER_API_KEY,
     },
+    resolve: {
+      alias: {
+        '@honeybadger-io/js': HONEYBADGER_API_KEY
+          ? '@honeybadger-io/js'
+          : resolve(__dirname, 'src/honeybadgerStub.ts'),
+      },
+    },
     define: {
       'import.meta.env.SCRIVITO_ORIGIN': JSON.stringify(scrivitoOrigin(env)),
       'import.meta.env.SCRIVITO_TENANT': JSON.stringify(env.SCRIVITO_TENANT),


### PR DESCRIPTION
This way boot time exceptions are also reliably logged to Honeybadger.

The stub is provided to reduce payload, if Honeybadger is not needed.