### PR TITLE
DataSearchResult

### DIFF
--- a/.knip.jsonc
+++ b/.knip.jsonc
@@ -11,7 +11,6 @@
     "src/Widgets/**/*{Component,EditingConfig,WidgetClass}.{ts,tsx}",
   ],
   "ignore": [
-    "src/Data/localStorageDataConnection.ts", // TODO: Remove from knip, once searchLocalStorageDataConnections is in use
     "src/honeybadgerStub.ts",
     "public/scrivito/**",
     "src/assets/stylesheets/vendor/**",

--- a/src/Data/DataSearchResult/DataSearchResultDataClass.ts
+++ b/src/Data/DataSearchResult/DataSearchResultDataClass.ts
@@ -1,6 +1,6 @@
 import { currentLanguage, load, provideDataClass } from 'scrivito'
 import { pisaClient } from '../pisaClient'
-import { getDataItemUrl } from './getDataItemUrl'
+import { loadDataItemUrl } from './loadDataItemUrl'
 import { dataSearchResultIndexFallback } from './dataSearchResultIndexFallback'
 
 export const DataSearchResult = provideDataClass('DataSearchResult', {
@@ -74,7 +74,7 @@ export const DataSearchResult = provideDataClass('DataSearchResult', {
             entity,
             snippet,
             title,
-            url: await getDataItemUrl(entity, _id),
+            url: await loadDataItemUrl(entity, _id),
           }
         }),
       )

--- a/src/Data/DataSearchResult/DataSearchResultDataClass.ts
+++ b/src/Data/DataSearchResult/DataSearchResultDataClass.ts
@@ -4,11 +4,12 @@ import { loadDataItemUrl } from './loadDataItemUrl'
 import { dataSearchResultIndexFallback } from './dataSearchResultIndexFallback'
 
 export const DataSearchResult = provideDataClass('DataSearchResult', {
-  title: async () =>
-    (await load(() => currentLanguage())) === 'de'
+  async title() {
+    return (await load(() => currentLanguage())) === 'de'
       ? 'Suchtreffer (Daten)'
-      : 'Search result (data)',
-  attributes: async () => {
+      : 'Search result (data)'
+  },
+  async attributes() {
     const lang = await load(() => currentLanguage())
 
     return {

--- a/src/Data/DataSearchResult/DataSearchResultDataClass.ts
+++ b/src/Data/DataSearchResult/DataSearchResultDataClass.ts
@@ -29,10 +29,10 @@ export const DataSearchResult = provideDataClass('DataSearchResult', {
         throw new Error('Search result (data) does not support sorting.')
       }
 
+      if (!params.search()) return { results: [], count: 0 }
+
       const globalResultClient = await pisaClient('global-result')
       if (!globalResultClient) return dataSearchResultIndexFallback(params)
-
-      if (!params.search()) return { results: [], count: 0 }
 
       const classNames = [
         'Contract',

--- a/src/Data/DataSearchResult/DataSearchResultDataClass.ts
+++ b/src/Data/DataSearchResult/DataSearchResultDataClass.ts
@@ -1,0 +1,85 @@
+import { currentLanguage, load, provideDataClass } from 'scrivito'
+import { pisaClient } from '../pisaClient'
+import { getDataItemUrl } from './getDataItemUrl'
+import { dataSearchResultIndexFallback } from './dataSearchResultIndexFallback'
+
+export const DataSearchResult = provideDataClass('DataSearchResult', {
+  title: async () =>
+    (await load(() => currentLanguage())) === 'de'
+      ? 'Suchtreffer (Daten)'
+      : 'Search result (data)',
+  attributes: async () => {
+    const lang = await load(() => currentLanguage())
+
+    return {
+      entity: ['string', { title: lang === 'de' ? 'Entität' : 'Entity' }],
+      snippet: ['string', { title: lang === 'de' ? 'Schnipsel' : 'Snippet' }],
+      title: ['string', { title: lang === 'de' ? 'Titel' : 'Title' }],
+      url: ['unknown', { title: 'URL' }],
+    }
+  },
+  connection: {
+    async index(params) {
+      if (Object.keys(params.filters()).length > 0) {
+        throw new Error('Search result (data) does not support filtering.')
+      }
+
+      if (params.order().length > 0) {
+        throw new Error('Search result (data) does not support sorting.')
+      }
+
+      const globalResultClient = await pisaClient('global-result')
+      if (!globalResultClient) return dataSearchResultIndexFallback(params)
+
+      if (!params.search()) return { results: [], count: 0 }
+
+      const classNames = [
+        'Contract',
+        'Document',
+        'Event',
+        'Order',
+        'Quote',
+        'ServiceObject',
+        'Ticket',
+      ]
+
+      const {
+        results: rawResults,
+        count,
+        continuation,
+      } = (await globalResultClient.get('', {
+        params: {
+          _continuation: params.continuation(),
+          _count: params.includeCount().toString(),
+          _limit: params.limit().toString(),
+          _search: params.search(),
+          entity: classNames.join(','),
+        },
+      })) as {
+        results: Array<{
+          _id: string
+          entity: string
+          matches: Array<[number, number]>
+          snippet: string
+          title: string
+        }>
+        count?: number
+        continuation?: string
+      }
+
+      const results = await Promise.all(
+        rawResults.map(async ({ _id, entity, title, snippet }) => {
+          return {
+            _id,
+            entity,
+            snippet,
+            title,
+            url: await getDataItemUrl(entity, _id),
+          }
+        }),
+      )
+
+      return { results, count, continuation }
+    },
+  },
+})

--- a/src/Data/DataSearchResult/DataSearchResultDataClass.ts
+++ b/src/Data/DataSearchResult/DataSearchResultDataClass.ts
@@ -3,6 +3,16 @@ import { pisaClient } from '../pisaClient'
 import { loadDataItemUrl } from './loadDataItemUrl'
 import { dataSearchResultIndexFallback } from './dataSearchResultIndexFallback'
 
+const CLASS_NAMES = [
+  'Contract',
+  'Document',
+  'Event',
+  'Order',
+  'Quote',
+  'ServiceObject',
+  'Ticket',
+]
+
 export const DataSearchResult = provideDataClass('DataSearchResult', {
   async title() {
     return (await load(() => currentLanguage())) === 'de'
@@ -32,17 +42,9 @@ export const DataSearchResult = provideDataClass('DataSearchResult', {
       if (!params.search()) return { results: [], count: 0 }
 
       const globalResultClient = await pisaClient('global-result')
-      if (!globalResultClient) return dataSearchResultIndexFallback(params)
-
-      const classNames = [
-        'Contract',
-        'Document',
-        'Event',
-        'Order',
-        'Quote',
-        'ServiceObject',
-        'Ticket',
-      ]
+      if (!globalResultClient) {
+        return dataSearchResultIndexFallback(params, CLASS_NAMES)
+      }
 
       const {
         results: rawResults,
@@ -54,7 +56,7 @@ export const DataSearchResult = provideDataClass('DataSearchResult', {
           _count: params.includeCount().toString(),
           _limit: params.limit().toString(),
           _search: params.search(),
-          entity: classNames.join(','),
+          entity: CLASS_NAMES.join(','),
         },
       })) as {
         results: Array<{

--- a/src/Data/DataSearchResult/dataSearchResultIndexFallback.ts
+++ b/src/Data/DataSearchResult/dataSearchResultIndexFallback.ts
@@ -19,11 +19,8 @@ const NON_SNIPPET_KEYS = ['_id']
 export async function dataSearchResultIndexFallback(
   params: DataConnectionIndexParams,
 ) {
-  const search = params.search()
-  if (!search) return { results: [], count: 0 }
-
   const rawResults = await searchLocalStorageDataConnections(
-    search,
+    params.search(),
     INCLUDED_CLASS_NAMES,
   )
 

--- a/src/Data/DataSearchResult/dataSearchResultIndexFallback.ts
+++ b/src/Data/DataSearchResult/dataSearchResultIndexFallback.ts
@@ -4,24 +4,15 @@ import { searchLocalStorageDataConnections } from '../localStorageDataConnection
 import { ensureString } from '../../utils/ensureString'
 import { loadDataItemUrl } from './loadDataItemUrl'
 
-const INCLUDED_CLASS_NAMES = [
-  'Contract',
-  'Document',
-  'Event',
-  'Order',
-  'Quote',
-  'ServiceObject',
-  'Ticket',
-]
-
 const NON_SNIPPET_KEYS = ['_id']
 
 export async function dataSearchResultIndexFallback(
   params: DataConnectionIndexParams,
+  classNames: string[],
 ) {
   const rawResults = await searchLocalStorageDataConnections(
     params.search(),
-    INCLUDED_CLASS_NAMES,
+    classNames,
   )
 
   const allResults = await Promise.all(

--- a/src/Data/DataSearchResult/dataSearchResultIndexFallback.ts
+++ b/src/Data/DataSearchResult/dataSearchResultIndexFallback.ts
@@ -1,0 +1,56 @@
+import { truncate } from 'lodash-es'
+import { DataConnectionIndexParams } from 'scrivito'
+import { searchLocalStorageDataConnections } from '../localStorageDataConnection'
+import { ensureString } from '../../utils/ensureString'
+import { getDataItemUrl } from './getDataItemUrl'
+
+const INCLUDED_CLASS_NAMES = [
+  'Contract',
+  'Document',
+  'Event',
+  'Order',
+  'Quote',
+  'ServiceObject',
+  'Ticket',
+]
+
+const NON_SNIPPET_KEYS = ['_id']
+
+export async function dataSearchResultIndexFallback(
+  params: DataConnectionIndexParams,
+) {
+  const search = params.search()
+  if (!search) return { results: [], count: 0 }
+
+  const rawResults = await searchLocalStorageDataConnections(
+    search,
+    INCLUDED_CLASS_NAMES,
+  )
+
+  const allResults = await Promise.all(
+    rawResults.map(async ({ _id, className, rawItem }) => ({
+      _id,
+      entity: className,
+      snippet: calculateSnippet(rawItem),
+      title: ensureString(rawItem.title) || ensureString(rawItem.keyword),
+      url: await getDataItemUrl(className, _id),
+    })),
+  )
+
+  const limit = params.limit()
+  const results = allResults.slice(Number(params.continuation() ?? 0), limit)
+  const continuation = limit < allResults.length ? limit.toString() : undefined
+
+  return { results, count: allResults.length, continuation }
+}
+
+function calculateSnippet(rawItem: Record<string, unknown>): string {
+  const allValues = Object.entries(rawItem)
+    .filter(
+      ([key, value]) =>
+        typeof value === 'string' && !!value && !NON_SNIPPET_KEYS.includes(key),
+    )
+    .map(([_key, value]) => value)
+
+  return truncate(allValues.join(' | '), { length: 297, separator: /,? +/ })
+}

--- a/src/Data/DataSearchResult/dataSearchResultIndexFallback.ts
+++ b/src/Data/DataSearchResult/dataSearchResultIndexFallback.ts
@@ -2,7 +2,7 @@ import { truncate } from 'lodash-es'
 import { DataConnectionIndexParams } from 'scrivito'
 import { searchLocalStorageDataConnections } from '../localStorageDataConnection'
 import { ensureString } from '../../utils/ensureString'
-import { getDataItemUrl } from './getDataItemUrl'
+import { loadDataItemUrl } from './loadDataItemUrl'
 
 const INCLUDED_CLASS_NAMES = [
   'Contract',
@@ -33,7 +33,7 @@ export async function dataSearchResultIndexFallback(
       entity: className,
       snippet: calculateSnippet(rawItem),
       title: ensureString(rawItem.title) || ensureString(rawItem.keyword),
-      url: await getDataItemUrl(className, _id),
+      url: await loadDataItemUrl(className, _id),
     })),
   )
 

--- a/src/Data/DataSearchResult/getDataItemUrl.ts
+++ b/src/Data/DataSearchResult/getDataItemUrl.ts
@@ -1,0 +1,14 @@
+import { getDataClass, load, urlForDataItem } from 'scrivito'
+
+export async function getDataItemUrl(
+  dataClassName: string,
+  id: string,
+): Promise<string | null> {
+  const dataClass = getDataClass(dataClassName)
+  if (!dataClass) return null
+
+  const dataItem = await load(() => dataClass.get(id))
+  if (!dataItem) return null
+
+  return load(() => urlForDataItem(dataItem))
+}

--- a/src/Data/DataSearchResult/loadDataItemUrl.ts
+++ b/src/Data/DataSearchResult/loadDataItemUrl.ts
@@ -1,6 +1,6 @@
 import { getDataClass, load, urlForDataItem } from 'scrivito'
 
-export async function getDataItemUrl(
+export async function loadDataItemUrl(
   dataClassName: string,
   id: string,
 ): Promise<string | null> {

--- a/src/Data/DataSearchResult/loadDataItemUrl.ts
+++ b/src/Data/DataSearchResult/loadDataItemUrl.ts
@@ -7,8 +7,8 @@ export async function loadDataItemUrl(
   const dataClass = getDataClass(dataClassName)
   if (!dataClass) return null
 
-  const dataItem = await load(() => dataClass.get(id))
-  if (!dataItem) return null
-
-  return load(() => urlForDataItem(dataItem))
+  return load(() => {
+    const dataItem = dataClass.get(id)
+    return dataItem ? urlForDataItem(dataItem) : null
+  })
 }


### PR DESCRIPTION
Content to review the changes - https://edit.scrivito.com/d0a154d76edf2a7bd991fc658e700a1d~https://data-search-result.scrivito-portal-app.pages.dev/en/search-results?q=Tynacoon&_scrivito_workspace_id=p6d384dda43ac613&_scrivito_display_mode=view

⚠️ Do not publish the working copy yet ⚠️!

The goal of this PR is to add `DataSearchResult` similar to the existing `ContentSearchResult`. For that the API of https://docs.google.com/document/d/1sIxmlC5BuQouu5TKZMwrdG6R-6Mrs4w57GQiymvTJ8U/edit?tab=t.0#heading=h.7zv8ou23o8xp is implemented.