### PR TITLE
CardWidget: Fix issue when placed in a data column widget

### DIFF
--- a/src/Widgets/CardWidget/CardWidgetComponent.tsx
+++ b/src/Widgets/CardWidget/CardWidgetComponent.tsx
@@ -77,7 +77,7 @@ provideComponent(CardWidget, ({ widget }) => {
 
 const LinkOrNotTag = connect(
   ({ children, link }: { children: React.ReactNode; link: Link | null }) => {
-    if (!link) return <>{children}</>
+    if (!link) return <div>{children}</div>
 
     return (
       <LinkTag


### PR DESCRIPTION
How to reproduce:
1. Have a Data Column Widget with multiple data items
2. Place a Card Widget within the data column.
3. Add something within the card, e.g. a static image
4. Enable the "Show footer" option of the card widget
5. In the now available footer add a DataLabelWidget and select an attribute. Ideally the attribute should have varying length, so that it sometimes needs one line and sometimes two lines.

Expected (now with this commit): The DataLabelWidget is always "top aligned". See the live version of this PR: https://edit.scrivito.com/d0a154d76edf2a7bd991fc658e700a1d~https://card-widget-bugfix.scrivito-portal-app.pages.dev/en/reproduce-card-issue-2c350dca8ec03e91?_scrivito_workspace_id=rac62e792d2700d4&_scrivito_display_mode=view

Actual (prior to this commit): As long as no "Link to" is set, the footer seems to be "bottom aligned". See a live version at https://edit.scrivito.com/d0a154d76edf2a7bd991fc658e700a1d~https://main.scrivito-portal-app.pages.dev/en/reproduce-card-issue-2c350dca8ec03e91?_scrivito_workspace_id=rac62e792d2700d4&_scrivito_display_mode=view .