### PR TITLE
Font: Consider `application/font-woff` to be a font

### DIFF
--- a/src/config/objClassForContentType.ts
+++ b/src/config/objClassForContentType.ts
@@ -3,6 +3,7 @@ import { configureObjClassForContentType as scrivitoConfigureObjClassForContentT
 export function configureObjClassForContentType() {
   scrivitoConfigureObjClassForContentType({
     'font/*': 'Font',
+    'application/font-woff': 'Font',
     'image/*': 'Image',
     'video/*': 'Video',
     '*/*': 'Download',


### PR DESCRIPTION
This is the old mime-type still in use by some systems (e.g. recent MacOS). See https://www.iana.org/assignments/media-types/media-types.xhtml for reference.

How to reproduce: Download `woff` version from https://de.bestfonts.pro/font/arbutus-slab and try to use it as a custom font.

Originally reported by @agessler.