### PR TITLE
Fix widget library styling

### DIFF
--- a/_scrivito_extensions.html
+++ b/_scrivito_extensions.html
@@ -12,6 +12,7 @@
     <link rel="preconnect" href="https://api.scrivito.com" crossorigin />
     <link rel="preconnect" href="https://api.scrivito.com" />
     <link rel="preconnect" href="https://cdn0.scrvt.com" />
+    <link rel="stylesheet" href="/src/assets/stylesheets/index.scss" />
     <link
       rel="stylesheet"
       href="/src/assets/stylesheets/scrivitoExtensions.scss"

--- a/src/Components/ScrivitoExtensions/SocialCardsTab.scss
+++ b/src/Components/ScrivitoExtensions/SocialCardsTab.scss
@@ -24,7 +24,7 @@
 }
 
 .scrivito_detail_label span.headline {
-  font-size: 18px;
+  font-size: 11px;
   color: #777;
 }
 

--- a/src/assets/stylesheets/index.scss
+++ b/src/assets/stylesheets/index.scss
@@ -473,15 +473,6 @@ a.btn {
   color: #333;
 }
 
-.scrivito_editing_active ::selection {
-  background: #507ab5 !important;
-  color: #fff !important;
-}
-.scrivito_editing_active .gle ::selection {
-  background: transparent !important;
-  color: inherit !important;
-}
-
 .text-clamp {
   overflow: hidden;
   text-overflow: ellipsis;

--- a/src/assets/stylesheets/index.scss
+++ b/src/assets/stylesheets/index.scss
@@ -473,9 +473,13 @@ a.btn {
   color: #333;
 }
 
-.scrivito_editing_active *::selection {
-  background: #507ab5;
-  color: #fff;
+.scrivito_editing_active ::selection {
+  background: #507ab5 !important;
+  color: #fff !important;
+}
+.scrivito_editing_active .gle ::selection {
+  background: transparent !important;
+  color: inherit !important;
 }
 
 .text-clamp {

--- a/src/assets/stylesheets/index.scss
+++ b/src/assets/stylesheets/index.scss
@@ -473,6 +473,11 @@ a.btn {
   color: #333;
 }
 
+.scrivito_editing_active *::selection {
+  background: #507ab5;
+  color: #fff;
+}
+
 .text-clamp {
   overflow: hidden;
   text-overflow: ellipsis;

--- a/src/assets/stylesheets/scrivitoEditing.scss
+++ b/src/assets/stylesheets/scrivitoEditing.scss
@@ -12,3 +12,12 @@
   opacity: 0 !important;
   width: 17px !important;
 }
+
+.scrivito_editing_active ::selection {
+  background: #507ab5 !important;
+  color: #fff !important;
+}
+.scrivito_editing_active .gle ::selection {
+  background: transparent !important;
+  color: inherit !important;
+}


### PR DESCRIPTION
Fixes https://github.com/infopark/scrivito_js/issues/11903.

Custom colors and fonts are currently not used in the widget library.