### PR TITLE
CardWidget: Bugfix styling of footer, if link is set

### DIFF
--- a/src/Widgets/CardWidget/CardWidgetComponent.tsx
+++ b/src/Widgets/CardWidget/CardWidgetComponent.tsx
@@ -47,8 +47,9 @@ provideComponent(CardWidget, ({ widget }) => {
           />
         </InPlaceEditingOff>
       )}
-      <LinkOrNotTag link={widget.get('linkTo')}>
-        {image && (
+
+      {image && (
+        <LinkOrNotTag link={widget.get('linkTo')}>
           <InPlaceEditingOff>
             <ImageTag
               content={widget}
@@ -57,31 +58,41 @@ provideComponent(CardWidget, ({ widget }) => {
               alt={alternativeTextForObj(widget.get('image'))}
             />
           </InPlaceEditingOff>
-        )}
-        <ContentTag
-          content={widget}
-          attribute="cardBody"
-          className={cardBodyClassNames.join(' ')}
-        />
-        {widget.get('showFooter') && (
-          <ContentTag
-            content={widget}
-            attribute="cardFooter"
-            className="card-footer"
-          />
-        )}
+        </LinkOrNotTag>
+      )}
+
+      <LinkOrNotTag
+        link={widget.get('linkTo')}
+        className={cardBodyClassNames.join(' ')}
+      >
+        <ContentTag content={widget} attribute="cardBody" />
       </LinkOrNotTag>
+
+      {widget.get('showFooter') && (
+        <LinkOrNotTag link={widget.get('linkTo')} className="card-footer">
+          <ContentTag content={widget} attribute="cardFooter" />
+        </LinkOrNotTag>
+      )}
     </WidgetTag>
   )
 })
 
 const LinkOrNotTag = connect(
-  ({ children, link }: { children: React.ReactNode; link: Link | null }) => {
-    if (!link) return <>{children}</>
+  ({
+    children,
+    className,
+    link,
+  }: {
+    children: React.ReactNode
+    className?: string
+    link: Link | null
+  }) => {
+    if (!link) return <div className={className}>{children}</div>
 
     return (
       <LinkTag
         to={link}
+        className={className}
         draggable={!isInPlaceEditingActive()} // Workaround for https://bugzilla.mozilla.org/show_bug.cgi?id=1177704
       >
         {children}


### PR DESCRIPTION
Next try, after https://github.com/Scrivito/scrivito-portal-app/pull/864 did not work properly.

Bootstrap requires, that "card-footer" is a direct child of "card-footer" to be correctly aligned (at the bottom).

Previously this only worked, if _no_ link was set. Now it always works, independent of the link.

How to reproduce:
1. Have a Data Column Widget with multiple data items
2. Place a Card Widget within the data column.
3. Add something within the card, e.g. a static image
4. Enable the "Show footer" option of the card widget
5. In the now available footer add a DataLabelWidget and select an attribute. Ideally the attribute should have varying length, so that it sometimes needs one line and sometimes two lines.

Expected (now with this commit): The DataLabelWidget is always "bottom aligned". See the live version of this PR: https://edit.scrivito.com/d0a154d76edf2a7bd991fc658e700a1d~https://card-widget-bugfix.scrivito-portal-app.pages.dev/en/reproduce-card-issue-2c350dca8ec03e91?_scrivito_workspace_id=rac62e792d2700d4&_scrivito_display_mode=view

Actual (prior to this commit): As long as no "Link to" is set, the footer seems to be "top aligned". See a live version at https://edit.scrivito.com/d0a154d76edf2a7bd991fc658e700a1d~https://main.scrivito-portal-app.pages.dev/en/reproduce-card-issue-2c350dca8ec03e91?_scrivito_workspace_id=rac62e792d2700d4&_scrivito_display_mode=view .