### PR TITLE
PageTitleWidget: Use level h1

### DIFF
--- a/src/Widgets/PageTitleWidget/PageTitleWidgetComponent.tsx
+++ b/src/Widgets/PageTitleWidget/PageTitleWidgetComponent.tsx
@@ -6,14 +6,14 @@ provideComponent(PageTitleWidget, ({ widget }) => {
 
   return (
     <div className="header-caption">
-      <h3 className="h3">
+      <h1 className="h3">
         <ContentTag
           content={currentPage()}
           attribute="title"
           tag="span"
           className={`bg-${backgroundColor}`}
         />
-      </h3>
+      </h1>
     </div>
   )
 })


### PR DESCRIPTION
Most PageTitleWidgets will be placed at the very top of the page. Therefore a h1 is quite fitting. Styling is not affected.