### PR TITLE
Support multi-site in addition to multi-language

### DIFF
--- a/src/Components/NotFoundErrorPage.tsx
+++ b/src/Components/NotFoundErrorPage.tsx
@@ -9,7 +9,7 @@ import {
   NotFoundErrorPage as ScrivitoNotFoundErrorPage,
 } from 'scrivito'
 import { Loading } from './Loading'
-import { isNoSitePresent } from '../config/scrivitoSites'
+import { isNoSitePresent } from '../multiSite/isNoSitePresent'
 
 // Make sure, that you have a proxy running for these URLs, otherwise you'll see an endless loop.
 const RELOAD_SUBPATHS = ['/auth']

--- a/src/Components/NotFoundErrorPage.tsx
+++ b/src/Components/NotFoundErrorPage.tsx
@@ -9,14 +9,18 @@ import {
   NotFoundErrorPage as ScrivitoNotFoundErrorPage,
 } from 'scrivito'
 import { Loading } from './Loading'
-import { isNoSitePresent } from '../multiSite/isNoSitePresent'
 
 // Make sure, that you have a proxy running for these URLs, otherwise you'll see an endless loop.
 const RELOAD_SUBPATHS = ['/auth']
 
 export const NotFoundErrorPage = connect(
   function NotFoundErrorPage() {
-    if (isUserLoggedIn() && isNoSitePresent()) return <NotFound />
+    if (
+      isUserLoggedIn() &&
+      !Obj.onAllSites().get(import.meta.env.SCRIVITO_ROOT_OBJ_ID)
+    ) {
+      return <NotFound />
+    }
 
     return (
       <ScrivitoNotFoundErrorPage>

--- a/src/Objs/Homepage/HomepageEditingConfig.ts
+++ b/src/Objs/Homepage/HomepageEditingConfig.ts
@@ -122,6 +122,7 @@ provideEditingConfig(Homepage, {
   properties: [...defaultPageProperties],
   initialContent: {
     ...defaultPageInitialContent,
+    contentFormat: 'portal-app:6',
     siteDropShadow: true,
     siteFontBodyWeight: '500',
     siteFontHeadlineWeight: '500',

--- a/src/config/scrivitoSites.ts
+++ b/src/config/scrivitoSites.ts
@@ -7,10 +7,7 @@ import {
   urlFor,
 } from 'scrivito'
 import { ensureString } from '../utils/ensureString'
-import {
-  getJrPlatformInstanceBaseUrl,
-  jrPlatformRedirectToSiteUrl,
-} from '../privateJrPlatform/multiTenancy'
+import { getJrPlatformInstanceBaseUrl } from '../privateJrPlatform/multiTenancy'
 
 const origin =
   typeof window !== 'undefined'
@@ -152,10 +149,6 @@ function redirectToSiteUrl(siteUrl: string) {
     (extractFromUrl(siteUrl).contentId === contentId
       ? location
       : defaultLocation) || ''
-
-  if (import.meta.env.PRIVATE_JR_PLATFORM) {
-    return jrPlatformRedirectToSiteUrl(siteUrl)
-  }
 
   window.location.assign(`${siteUrl}${path}${search}${hash}`)
 }

--- a/src/config/scrivitoSites.ts
+++ b/src/config/scrivitoSites.ts
@@ -57,21 +57,16 @@ export function siteForUrl(
 }
 
 function findSiteByUrl(url: string) {
-  const { contentId, language } = extractFromUrl(url)
-
+  const { contentId: urlContentId, language } = extractFromUrl(url)
   if (!language) return {}
 
-  if (contentId) {
-    const siteId = findSiteIdBy({ contentId, language })
-    if (!siteId) return {}
-    return { contentId, language, siteId }
-  }
+  const contentId = urlContentId || defaultSiteContentId()
+  if (!contentId) return {}
 
-  const siteId = getLanguageVersions()
-    ?.find((site) => site.language() === language)
-    ?.siteId()
+  const siteId = findSiteIdBy({ contentId, language })
   if (!siteId) return {}
-  return { contentId: defaultSiteContentId(), language, siteId }
+
+  return { contentId, language, siteId }
 }
 
 export function extractFromUrl(url: string): {

--- a/src/config/scrivitoSites.ts
+++ b/src/config/scrivitoSites.ts
@@ -53,7 +53,7 @@ export function siteForUrl(
 
   if (siteId) return { baseUrl: baseUrlFor(language, contentId), siteId }
 
-  if (getLanguageVersions()?.length) return findSiteForUrlExpensive(url)
+  return findSiteForUrlExpensive(url)
 }
 
 function findSiteByUrl(url: string) {

--- a/src/config/scrivitoSites.ts
+++ b/src/config/scrivitoSites.ts
@@ -55,6 +55,8 @@ function findSiteByUrl(url: string) {
   const { contentId: urlContentId, language } = extractFromUrl(url)
   if (!language) return {}
 
+  if (urlContentId === defaultSiteContentId()) return {}
+
   const contentId = urlContentId || defaultSiteContentId()
   if (!contentId) return {}
 

--- a/src/config/scrivitoSites.ts
+++ b/src/config/scrivitoSites.ts
@@ -129,19 +129,6 @@ function instanceBaseUrl(): string {
   return origin
 }
 
-export function getLanguageVersions(contentId?: string): Obj[] | undefined {
-  const root = contentId
-    ? Obj.onAllSites()
-        .where('_path', 'equals', '/')
-        .and('_contentId', 'equals', contentId)
-        .toArray()[0]
-    : undefined
-
-  return (
-    root || Obj.onAllSites().get(import.meta.env.SCRIVITO_ROOT_OBJ_ID)
-  )?.versionsOnAllSites()
-}
-
 function defaultSiteContentId() {
   return Obj.onAllSites()
     .get(import.meta.env.SCRIVITO_ROOT_OBJ_ID)

--- a/src/config/scrivitoSites.ts
+++ b/src/config/scrivitoSites.ts
@@ -60,7 +60,7 @@ export function siteForUrl(
 
   if (siteId) return { baseUrl: baseUrlFor(language, contentId), siteId }
 
-  if (defaultSiteLanguageVersions()?.length) return findSiteForUrlExpensive(url)
+  if (getLanguageVersions()?.length) return findSiteForUrlExpensive(url)
 }
 
 function findSiteByUrl(url: string) {
@@ -74,7 +74,7 @@ function findSiteByUrl(url: string) {
     return { contentId, language, siteId }
   }
 
-  const siteId = defaultSiteLanguageVersions()
+  const siteId = getLanguageVersions()
     ?.find((site) => site.language() === language)
     ?.siteId()
   if (!siteId) return {}
@@ -121,7 +121,7 @@ function configuredBaseUrlsFor(site: Obj) {
 }
 
 export function isNoSitePresent(): boolean {
-  return !defaultSiteLanguageVersions()?.length
+  return !getLanguageVersions()?.length
 }
 
 export async function ensureSiteIsPresent() {
@@ -158,7 +158,7 @@ function getPreferredSite() {
     window.location.origin + window.location.pathname,
   )
 
-  const languageVersions = defaultSiteLanguageVersions(contentId) || []
+  const languageVersions = getLanguageVersions(contentId) || []
   const preferredLanguageOrder = [...window.navigator.languages, 'en', null]
 
   for (const language of preferredLanguageOrder) {
@@ -187,7 +187,7 @@ function instanceBaseUrl(): string {
   return origin
 }
 
-function defaultSiteLanguageVersions(contentId?: string) {
+function getLanguageVersions(contentId?: string) {
   const root = contentId
     ? Obj.onAllSites()
         .where('_path', 'equals', '/')

--- a/src/config/scrivitoSites.ts
+++ b/src/config/scrivitoSites.ts
@@ -45,23 +45,27 @@ export function siteForUrl(
     return { baseUrl: neoletterBaseUrl, siteId: NEOLETTER_MAILINGS_SITE_ID }
   }
 
-  const language = languageForUrl(url)
-  const languageVersions = defaultSiteLanguageVersions()
-  const siteId = languageVersions
-    ?.find((site) => site.language() === language)
-    ?.siteId()
+  const { language, siteId } = languageAndSiteIdForUrl(url)
 
   if (language && siteId) {
     return { baseUrl: `${getBaseAppUrl()}/${language}`, siteId }
   }
-  if (languageVersions?.length) return findSiteForUrlExpensive(url)
+
+  if (defaultSiteLanguageVersions()?.length) return findSiteForUrlExpensive(url)
 }
 
-function languageForUrl(url: string) {
-  const regex = new RegExp(
-    `^${getBaseAppUrl()}\\/(?<lang>[a-z]{2}(-[A-Z]{2})?)([?/]|$)`,
-  )
-  return regex.exec(url)?.groups?.lang
+function languageAndSiteIdForUrl(url: string) {
+  const { language } =
+    new RegExp(
+      `^${getBaseAppUrl()}\\/(?<language>[a-z]{2}(-[A-Z]{2})?)([?/]|$)`,
+    ).exec(url)?.groups || {}
+
+  return {
+    language,
+    siteId: defaultSiteLanguageVersions()
+      ?.find((site) => site.language() === language)
+      ?.siteId(),
+  }
 }
 
 function findSiteForUrlExpensive(url: string) {

--- a/src/config/scrivitoSites.ts
+++ b/src/config/scrivitoSites.ts
@@ -56,10 +56,7 @@ export function siteForUrl(
 }
 
 function findSiteByUrl(url: string) {
-  const { contentId, language } =
-    new RegExp(
-      `^${instanceBaseUrl()}(\\/(?<contentId>[0-9a-z]{16}))?\\/(?<language>[a-z]{2}(-[A-Z]{2})?)([?/]|$)`,
-    ).exec(url)?.groups || {}
+  const { contentId, language } = extractFromUrl(url)
 
   if (contentId && language) {
     const siteId = findSiteIdBy({ contentId, language })
@@ -72,6 +69,14 @@ function findSiteByUrl(url: string) {
       ?.find((site) => site.language() === language)
       ?.siteId(),
   }
+}
+
+function extractFromUrl(url: string) {
+  return (
+    new RegExp(
+      `^${instanceBaseUrl()}(\\/(?<contentId>[0-9a-z]{16}))?\\/(?<language>[a-z]{2}(-[A-Z]{2})?)([?/]|$)`,
+    ).exec(url)?.groups || {}
+  )
 }
 
 function findSiteIdBy(query: { contentId: string; language: string }) {

--- a/src/config/scrivitoSites.ts
+++ b/src/config/scrivitoSites.ts
@@ -141,7 +141,11 @@ function redirectToSiteUrl(siteUrl: string) {
 }
 
 function getPreferredSite() {
-  const languageVersions = defaultSiteLanguageVersions() || []
+  const { contentId } = extractFromUrl(
+    window.location.origin + window.location.pathname,
+  )
+
+  const languageVersions = defaultSiteLanguageVersions(contentId) || []
   const preferredLanguageOrder = [...window.navigator.languages, 'en', null]
 
   for (const language of preferredLanguageOrder) {
@@ -151,7 +155,7 @@ function getPreferredSite() {
     if (site) return site
   }
 
-  return languageVersions[0] || null
+  return languageVersions[0]
 }
 
 function baseUrlFor(language: string, contentId?: string) {
@@ -170,10 +174,17 @@ function instanceBaseUrl(): string {
   return origin
 }
 
-function defaultSiteLanguageVersions() {
-  return Obj.onAllSites()
-    .get(import.meta.env.SCRIVITO_ROOT_OBJ_ID)
-    ?.versionsOnAllSites()
+function defaultSiteLanguageVersions(contentId?: string) {
+  const root = contentId
+    ? Obj.onAllSites()
+        .where('_path', 'equals', '/')
+        .and('_contentId', 'equals', contentId)
+        .toArray()[0]
+    : undefined
+
+  return (
+    root || Obj.onAllSites().get(import.meta.env.SCRIVITO_ROOT_OBJ_ID)
+  )?.versionsOnAllSites()
 }
 
 function defaultSiteContentId() {

--- a/src/config/scrivitoSites.ts
+++ b/src/config/scrivitoSites.ts
@@ -1,11 +1,6 @@
 import { Obj, getInstanceId } from 'scrivito'
-import { ensureString } from '../utils/ensureString'
-import { getJrPlatformInstanceBaseUrl } from '../privateJrPlatform/multiTenancy'
-
-const origin =
-  typeof window !== 'undefined'
-    ? window.location.origin
-    : ensureString(import.meta.env.SCRIVITO_ORIGIN)
+import { instanceBaseUrl } from '../multiSite/instanceBaseUrl'
+import { extractFromUrl } from '../multiSite/extractFromUrl'
 
 const NEOLETTER_MAILINGS_SITE_ID = 'mailing-app'
 
@@ -69,19 +64,6 @@ function findSiteByUrl(url: string) {
   return { contentId, language, siteId }
 }
 
-export function extractFromUrl(url: string): {
-  contentId?: string
-  defaultLocation?: string
-  language?: string
-  location?: string
-} {
-  return (
-    new RegExp(
-      `^${instanceBaseUrl()}(?<defaultLocation>(/(?<contentId>[0-9a-z]{16}))?(/(?<language>[a-z]{2}(-[A-Z]{2})?))?(?<location>([?/].*)|$))`,
-    ).exec(url)?.groups || {}
-  )
-}
-
 function findSiteIdBy(query: { contentId: string; language: string }) {
   return Obj.onAllSites()
     .where('_path', 'equals', '/')
@@ -118,15 +100,6 @@ function baseUrlFor(language: string, contentId?: string) {
   return contentId && contentId !== defaultSiteContentId()
     ? `${base}/${contentId}/${language}`
     : `${base}/${language}`
-}
-
-function instanceBaseUrl(): string {
-  if (!origin) throw new Error('No origin defined!')
-  if (import.meta.env.PRIVATE_JR_PLATFORM) {
-    return getJrPlatformInstanceBaseUrl(origin)
-  }
-
-  return origin
 }
 
 function defaultSiteContentId() {

--- a/src/config/scrivitoSites.ts
+++ b/src/config/scrivitoSites.ts
@@ -87,7 +87,7 @@ function findSiteByUrl(url: string) {
 function extractFromUrl(url: string) {
   return (
     new RegExp(
-      `^${instanceBaseUrl()}(\\/(?<contentId>[0-9a-z]{16}))?\\/(?<language>[a-z]{2}(-[A-Z]{2})?)([?/]|$)`,
+      `^${instanceBaseUrl()}(?<defaultLocation>(/(?<contentId>[0-9a-z]{16}))?(/(?<language>[a-z]{2}(-[A-Z]{2})?))?(?<location>([?/].*)|$))`,
     ).exec(url)?.groups || {}
   )
 }
@@ -143,12 +143,19 @@ export async function ensureSiteIsPresent() {
 }
 
 function redirectToSiteUrl(siteUrl: string) {
+  const { origin, pathname, search, hash } = window.location
+  const { contentId, defaultLocation, location } = extractFromUrl(
+    origin + pathname,
+  )
+
+  const path =
+    (extractFromUrl(siteUrl).contentId === contentId
+      ? location
+      : defaultLocation) || ''
+
   if (import.meta.env.PRIVATE_JR_PLATFORM) {
     return jrPlatformRedirectToSiteUrl(siteUrl)
   }
-
-  const { pathname, search, hash } = window.location
-  const path = pathname === '/' ? '' : pathname
 
   window.location.assign(`${siteUrl}${path}${search}${hash}`)
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -4,7 +4,6 @@ import './Data'
 import './Objs'
 import './Widgets'
 import { configure } from './config'
-import { ensureSiteIsPresent } from './config/scrivitoSites'
 import { verifySameWhoAmIUser } from './Data/CurrentUser/verifySameWhoAmIUser'
 import { renderOrHydrateApp } from './renderOrHydrateApp'
 import { getJrPlatformInstanceId } from './privateJrPlatform/multiTenancy'
@@ -13,6 +12,7 @@ import { StrictMode } from 'react'
 import { JrPlatformMissingTenant } from './privateJrPlatform/Components/JrPlatformMissingTenant'
 import { isJrPlatformValidContentFormat } from './privateJrPlatform/isJrPlatformValidContentFormat'
 import { JrPlatformWrongContentFormat } from './privateJrPlatform/Components/JrPlatformWrongContentFormat'
+import { ensureSiteIsPresent } from './multiSite/ensureSiteIsPresent'
 
 boot()
 

--- a/src/multiSite/ensureSiteIsPresent.ts
+++ b/src/multiSite/ensureSiteIsPresent.ts
@@ -5,7 +5,7 @@ import {
   Obj,
   urlFor,
 } from 'scrivito'
-import { extractFromUrl } from '../config/scrivitoSites'
+import { extractFromUrl } from './extractFromUrl'
 
 export async function ensureSiteIsPresent() {
   if (await load(() => currentSiteId())) return

--- a/src/multiSite/ensureSiteIsPresent.ts
+++ b/src/multiSite/ensureSiteIsPresent.ts
@@ -1,0 +1,63 @@
+import {
+  currentSiteId,
+  ensureUserIsLoggedIn,
+  load,
+  urlFor,
+  type Obj,
+} from 'scrivito'
+import { extractFromUrl, getLanguageVersions } from '../config/scrivitoSites'
+import { isNoSitePresent } from './isNoSitePresent'
+
+export async function ensureSiteIsPresent() {
+  if (await load(() => currentSiteId())) return
+
+  if (await load(() => isNoSitePresent())) {
+    ensureUserIsLoggedIn()
+    return
+  }
+
+  const site = await load(() => getPreferredSite())
+  if (!site) return
+
+  const siteUrl = await load(() => urlFor(site))
+  return redirectToSiteUrl(siteUrl)
+}
+
+function redirectToSiteUrl(siteUrl: string) {
+  const { origin, pathname, search, hash } = window.location
+  const { contentId, defaultLocation, location } = extractFromUrl(
+    origin + pathname,
+  )
+
+  const path =
+    (extractFromUrl(siteUrl).contentId === contentId
+      ? location
+      : defaultLocation) || ''
+
+  window.location.assign(`${siteUrl}${path}${search}${hash}`)
+}
+
+function getPreferredSite() {
+  const { contentId } = extractFromUrl(
+    window.location.origin + window.location.pathname,
+  )
+
+  const languageVersions = getLanguageVersions(contentId) || []
+  const preferredLanguageOrder = [...window.navigator.languages, 'en', null]
+
+  for (const language of preferredLanguageOrder) {
+    const site = languageVersions.find((site) =>
+      siteHasLanguage(site, language),
+    )
+    if (site) return site
+  }
+
+  return languageVersions[0]
+}
+
+function siteHasLanguage(site: Obj, language: string | null) {
+  const siteLanguage = site.language()
+  return language && siteLanguage
+    ? language.startsWith(siteLanguage)
+    : language === siteLanguage
+}

--- a/src/multiSite/ensureSiteIsPresent.ts
+++ b/src/multiSite/ensureSiteIsPresent.ts
@@ -5,7 +5,7 @@ import {
   Obj,
   urlFor,
 } from 'scrivito'
-import { extractFromUrl, getLanguageVersions } from '../config/scrivitoSites'
+import { extractFromUrl } from '../config/scrivitoSites'
 
 export async function ensureSiteIsPresent() {
   if (await load(() => currentSiteId())) return
@@ -56,6 +56,19 @@ function getPreferredSite() {
   }
 
   return languageVersions[0]
+}
+
+function getLanguageVersions(contentId?: string): Obj[] | undefined {
+  const root = contentId
+    ? Obj.onAllSites()
+        .where('_path', 'equals', '/')
+        .and('_contentId', 'equals', contentId)
+        .toArray()[0]
+    : undefined
+
+  return (
+    root || Obj.onAllSites().get(import.meta.env.SCRIVITO_ROOT_OBJ_ID)
+  )?.versionsOnAllSites()
 }
 
 function siteHasLanguage(site: Obj, language: string | null) {

--- a/src/multiSite/ensureSiteIsPresent.ts
+++ b/src/multiSite/ensureSiteIsPresent.ts
@@ -2,16 +2,19 @@ import {
   currentSiteId,
   ensureUserIsLoggedIn,
   load,
+  Obj,
   urlFor,
-  type Obj,
 } from 'scrivito'
 import { extractFromUrl, getLanguageVersions } from '../config/scrivitoSites'
-import { isNoSitePresent } from './isNoSitePresent'
 
 export async function ensureSiteIsPresent() {
   if (await load(() => currentSiteId())) return
 
-  if (await load(() => isNoSitePresent())) {
+  if (
+    await load(
+      () => !Obj.onAllSites().get(import.meta.env.SCRIVITO_ROOT_OBJ_ID),
+    )
+  ) {
     ensureUserIsLoggedIn()
     return
   }

--- a/src/multiSite/extractFromUrl.ts
+++ b/src/multiSite/extractFromUrl.ts
@@ -1,0 +1,14 @@
+import { instanceBaseUrl } from './instanceBaseUrl'
+
+export function extractFromUrl(url: string): {
+  contentId?: string
+  defaultLocation?: string
+  language?: string
+  location?: string
+} {
+  return (
+    new RegExp(
+      `^${instanceBaseUrl()}(?<defaultLocation>(/(?<contentId>[0-9a-z]{16}))?(/(?<language>[a-z]{2}(-[A-Z]{2})?))?(?<location>([?/].*)|$))`,
+    ).exec(url)?.groups || {}
+  )
+}

--- a/src/multiSite/instanceBaseUrl.ts
+++ b/src/multiSite/instanceBaseUrl.ts
@@ -1,0 +1,16 @@
+import { getJrPlatformInstanceBaseUrl } from '../privateJrPlatform/multiTenancy'
+import { ensureString } from '../utils/ensureString'
+
+const origin =
+  typeof window !== 'undefined'
+    ? window.location.origin
+    : ensureString(import.meta.env.SCRIVITO_ORIGIN)
+
+export function instanceBaseUrl(): string {
+  if (!origin) throw new Error('No origin defined!')
+  if (import.meta.env.PRIVATE_JR_PLATFORM) {
+    return getJrPlatformInstanceBaseUrl(origin)
+  }
+
+  return origin
+}

--- a/src/multiSite/isNoSitePresent.ts
+++ b/src/multiSite/isNoSitePresent.ts
@@ -1,5 +1,0 @@
-import { getLanguageVersions } from '../config/scrivitoSites'
-
-export function isNoSitePresent(): boolean {
-  return !getLanguageVersions()?.length
-}

--- a/src/multiSite/isNoSitePresent.ts
+++ b/src/multiSite/isNoSitePresent.ts
@@ -1,0 +1,5 @@
+import { getLanguageVersions } from '../config/scrivitoSites'
+
+export function isNoSitePresent(): boolean {
+  return !getLanguageVersions()?.length
+}

--- a/src/privateJrPlatform/isJrPlatformValidContentFormat.ts
+++ b/src/privateJrPlatform/isJrPlatformValidContentFormat.ts
@@ -1,7 +1,7 @@
 import { load, Obj } from 'scrivito'
 import { instanceFromHostname } from './multiTenancy'
 
-const CONTENT_FORMAT = 'portal-app:6'
+const EXPECTED_CONTENT_FORMAT = 'portal-app:6'
 const KNOWN_CONTENT_FORMATS: Record<string, string> = {
   'portal-app:5': 'https://v5.scrivito-portal-app.pages.dev',
   'portal-app:6': 'https://scrivito-portal-app.pages.dev',
@@ -19,7 +19,7 @@ export async function isJrPlatformValidContentFormat(): Promise<boolean> {
   if (!root) return true
 
   const siteContentFormat = root.get('contentFormat')
-  if (siteContentFormat === CONTENT_FORMAT) return true
+  if (siteContentFormat === EXPECTED_CONTENT_FORMAT) return true
 
   if (typeof siteContentFormat !== 'string') return false
   if (!siteContentFormat) return false

--- a/src/privateJrPlatform/multiTenancy.ts
+++ b/src/privateJrPlatform/multiTenancy.ts
@@ -23,7 +23,7 @@ export function getJrPlatformInstanceId(): string | null {
   return instance
 }
 
-export function getJrPlatformBaseAppUrl(origin: string): string {
+export function getJrPlatformInstanceBaseUrl(origin: string): string {
   if (!isMultitenancyEnabled()) return origin
 
   const instanceId = getJrPlatformInstanceId()

--- a/src/privateJrPlatform/multiTenancy.ts
+++ b/src/privateJrPlatform/multiTenancy.ts
@@ -32,19 +32,6 @@ export function getJrPlatformInstanceBaseUrl(origin: string): string {
   return `${origin}/${instanceId}`
 }
 
-export function jrPlatformRedirectToSiteUrl(siteUrl: string) {
-  const instanceId = getJrPlatformInstanceId()
-  if (!instanceId) throw new Error('Could not determine instance!')
-
-  const { pathname: rawPathname, search, hash } = window.location
-  const pathname = isMultitenancyEnabled()
-    ? rawPathname.slice(instanceId.length + 1)
-    : rawPathname
-  const path = pathname === '/' ? '' : pathname
-
-  window.location.assign(`${siteUrl}${path}${search}${hash}`)
-}
-
 function isMultitenancyEnabled(): boolean {
   return !import.meta.env.SCRIVITO_TENANT && !instanceFromHostname()
 }


### PR DESCRIPTION

It is pretty hard to keep the many possible URL formats and fallbacks in mind when changing the code.
Maybe we can come up with a better code structure in a follow-up. I've identified at least these responsibilities
- Known URL schemes and their precedence (including multi-tenancy, content-ID-based, default site, via baseUrl)
- Recognizing sites
- Redirecting to fallback URLs