### PR TITLE
disable styles for focus visible state in UI

### DIFF
--- a/src/assets/stylesheets/index.scss
+++ b/src/assets/stylesheets/index.scss
@@ -109,6 +109,14 @@ a:focus-visible,
   transition: all ease-in-out 0.3s;
 }
 
+[data-scrivito-editing] {
+  a:focus-visible,
+  .btn:focus-visible,
+  :focus-visible {
+    outline: none !important;
+  }
+}
+
 .btn {
   --bs-btn-border-color: transparent;
   --bs-btn-hover-border-color: transparent;


### PR DESCRIPTION
 FIX for https://github.com/Scrivito/scrivito-portal-app/issues/901
 
 I have disbales all focus-visible styles for data-attribute [data-scrivito-editing]. Was the only thing I found to address.