### PR TITLE
Use energy-content for now

### DIFF
--- a/src/privateJrPlatform/getJrPlatformConfig.ts
+++ b/src/privateJrPlatform/getJrPlatformConfig.ts
@@ -2,7 +2,7 @@ export function getJrPlatformConfig() {
   return {
     unstable: {
       initialContentDumpUrl:
-        'https://v6-content.scrivito-portal-app.pages.dev/index.json',
+        'https://energy-content.scrivito-portal-app.pages.dev/index.json',
       trustedUiOrigins: [
         'http://localhost:8090',
         'https://*.scrivito-ui.pages.dev',


### PR DESCRIPTION
Once we get clearance for the content it can move to `v6-content` as well.