### PR TITLE
redirectToSiteUrl: Remove trailing / from path

### DIFF
--- a/src/multiSite/ensureSiteIsPresent.ts
+++ b/src/multiSite/ensureSiteIsPresent.ts
@@ -32,10 +32,11 @@ function redirectToSiteUrl(siteUrl: string) {
     origin + pathname,
   )
 
-  const path =
+  const rawPath =
     (extractFromUrl(siteUrl).contentId === contentId
       ? location
       : defaultLocation) || ''
+  const path = rawPath.endsWith('/') ? rawPath.slice(0, -1) : rawPath
 
   window.location.assign(`${siteUrl}${path}${search}${hash}`)
 }


### PR DESCRIPTION
Follow up of https://github.com/Scrivito/scrivito-portal-app/pull/907.

It will be normalized by the SDK in the next step anyway.

How to reproduce:
* Visit https://main.scrivito-portal-app.pages.dev/ and look at the address bar
* For a brief moment the website visits `/en/` to rewrite that back to `/en`

With this branch:
* Visit https://reduce-url-rewrite.scrivito-portal-app.pages.dev/ and look at the address bar
* The website will directly rewrite to `/en`.