### PR TITLE
Homepage: Validate correct language

### DIFF
--- a/src/Objs/Homepage/HomepageEditingConfig.ts
+++ b/src/Objs/Homepage/HomepageEditingConfig.ts
@@ -1,4 +1,4 @@
-import { provideEditingConfig, Obj } from 'scrivito'
+import { provideEditingConfig } from 'scrivito'
 import { Homepage } from './HomepageObjClass'
 import { SiteColorsPicker } from './SiteColorsPicker'
 import {
@@ -140,12 +140,9 @@ provideEditingConfig(Homepage, {
           }
         }
 
-        const contentId = obj.contentId()
-        const duplicates = Obj.onAllSites()
-          .where('_objClass', 'equals', 'Homepage')
-          .and('_contentId', 'equals', contentId)
-          .and('_language', 'equals', language)
-          .count()
+        const duplicates = obj
+          .versionsOnAllSites()
+          .filter((version) => version.language() === language).length
 
         if (duplicates > 1) {
           return {


### PR DESCRIPTION
Follow up of https://github.com/Scrivito/scrivito-portal-app/pull/907.

Otherwise the multi-site setup might be broken.

The UX is probably not ideal, but at least you can't publish broken sites:

<img width="531" height="912" alt="No language" src="https://github.com/user-attachments/assets/6416a1df-8d0f-4b70-96c9-f894cb601762" />
<img width="532" height="899" alt="Multiple languages" src="https://github.com/user-attachments/assets/6ede06a0-ad0c-4468-a72a-6bdd215451e1" />
