### PR TITLE
Margin-Setting for Headline Widget (main)

### DIFF
--- a/src/Widgets/CardWidget/CardWidgetComponent.tsx
+++ b/src/Widgets/CardWidget/CardWidgetComponent.tsx
@@ -27,8 +27,7 @@ provideComponent(CardWidget, ({ widget }) => {
 
   const cardClassNames: string[] = ['card']
 
-  const margin = widget.get('margin')
-  cardClassNames.push(margin ? margin : 'mb-4')
+  cardClassNames.push(widget.get('margin') ?? 'mb-4')
 
   const backgroundColor = widget.get('backgroundColor') || 'white'
   cardClassNames.push(`bg-${backgroundColor}`)

--- a/src/Widgets/CardWidget/CardWidgetEditingConfig.ts
+++ b/src/Widgets/CardWidget/CardWidgetEditingConfig.ts
@@ -30,11 +30,11 @@ provideEditingConfig(CardWidget, {
     },
     padding: {
       title: 'Padding',
-      description: 'Inner space. Default: "p-4"',
+      description: 'Inner space. Default: p-4',
     },
     margin: {
       title: 'Margin',
-      description: 'Space below the widget. Default: "mb-4"',
+      description: 'Space below the widget. Default: mb-4',
     },
   },
   properties: (widget) => [

--- a/src/Widgets/DataCountWidget/DataCountWidgetEditingConfig.ts
+++ b/src/Widgets/DataCountWidget/DataCountWidgetEditingConfig.ts
@@ -25,7 +25,7 @@ provideEditingConfig(DataCountWidget, {
     },
     margin: {
       title: 'Margin',
-      description: 'Space below the widget. Default: "mb-2"',
+      description: 'Space below the widget. Default: mb-2',
     },
     style: {
       title: 'Style',

--- a/src/Widgets/DataSearchWidget/DataSearchWidgetEditingConfig.ts
+++ b/src/Widgets/DataSearchWidget/DataSearchWidgetEditingConfig.ts
@@ -23,7 +23,7 @@ provideEditingConfig(DataSearchWidget, {
     },
     margin: {
       title: 'Margin',
-      description: 'Space below the widget. Default: "mb-3"',
+      description: 'Space below the widget. Default: mb-3',
     },
     placeholder: {
       title: 'Input placeholder text',

--- a/src/Widgets/HeadlineWidget/HeadlineWidgetClass.ts
+++ b/src/Widgets/HeadlineWidget/HeadlineWidgetClass.ts
@@ -5,6 +5,10 @@ export const HeadlineWidget = provideWidgetClass('HeadlineWidget', {
     alignment: ['enum', { values: ['left', 'center', 'right'] }],
     headline: 'string',
     level: ['enum', { values: ['h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'div'] }],
+    margin: [
+      'enum',
+      { values: ['mb-0', 'mb-1', 'mb-2', 'mb-3', 'mb-4', 'mb-5'] },
+    ],
     style: [
       'enum',
       {

--- a/src/Widgets/HeadlineWidget/HeadlineWidgetComponent.tsx
+++ b/src/Widgets/HeadlineWidget/HeadlineWidgetComponent.tsx
@@ -20,6 +20,8 @@ provideComponent(HeadlineWidget, ({ widget }) => {
 
   if (widget.get('uppercase')) classNames.push('text-uppercase')
 
+  classNames.push(widget.get('margin') ?? 'mb-2')
+
   return (
     <ContentTag
       content={widget}

--- a/src/Widgets/HeadlineWidget/HeadlineWidgetEditingConfig.ts
+++ b/src/Widgets/HeadlineWidget/HeadlineWidgetEditingConfig.ts
@@ -50,12 +50,17 @@ provideEditingConfig(HeadlineWidget, {
         { value: 'right', title: 'Right' },
       ],
     },
+    margin: {
+      title: 'Margin',
+      description: 'Space below the widget. Default: mb-2',
+    },
     uppercase: { title: 'Uppercase?', description: 'Default: No' },
   },
-  properties: ['style', 'level', 'alignment', 'uppercase'],
+  properties: ['style', 'level', 'alignment', 'margin', 'uppercase'],
   initialContent: {
     alignment: 'left',
     headline: 'Headline',
+    margin: 'mb-2',
     style: 'h2',
   },
   validations: [

--- a/src/Widgets/SliderWidget/SliderWidgetEditingConfig.ts
+++ b/src/Widgets/SliderWidget/SliderWidgetEditingConfig.ts
@@ -21,7 +21,7 @@ provideEditingConfig(SliderWidget, {
     },
     margin: {
       title: 'Margin',
-      description: 'Space below the widget. Default: "mb-4"',
+      description: 'Space below the widget. Default: mb-4',
     },
     minHeight: {
       title: 'Minimum height (in px)',

--- a/src/assets/stylesheets/index.scss
+++ b/src/assets/stylesheets/index.scss
@@ -453,7 +453,7 @@ h5,
 h6 {
   line-height: 1.4;
   letter-spacing: -0.5px;
-  margin-bottom: 0.7rem;
+  margin-bottom: 0.5rem;
 }
 
 a {


### PR DESCRIPTION
[Concept](https://docs.google.com/document/d/1q4RqsL8alSl34ulBr2WRdOhKJMfQtz-fFnzSRXYp4fY/edit?tab=t.0#heading=h.raifs2th3xnv)

https://github.com/Scrivito/scrivito-portal-app/pull/897 but now for `main`.

Needs content: https://edit.scrivito.com/d0a154d76edf2a7bd991fc658e700a1d~https://headline-margin.scrivito-portal-app.pages.dev/en?_scrivito_workspace_id=jfca2d5b869212d5&_scrivito_display_mode=diff


Uses content script:
```
Scrivito.Obj.onAllSites()
    .all()
    .andNot('_siteId', 'equals', 'mailing-app')
    .and('_objClass', 'equals', ['HeadlineWidget']).take().map(o => o.widgets().filter(w => w.objClass() === 'HeadlineWidget').map(w => w.update({ margin: 'mb-2'})))
```