### PR TITLE
CardWidget allows video background (main)

### DIFF
--- a/src/Components/ImageOrVideo.tsx
+++ b/src/Components/ImageOrVideo.tsx
@@ -1,0 +1,44 @@
+import { connect, Widget, InPlaceEditingOff, ImageTag } from 'scrivito'
+
+export const ImageOrVideo = connect(function ImageOrVideo<T extends string>({
+  attribute,
+  className,
+  widget,
+}: {
+  attribute: T
+  className?: string
+  widget: Widget<{
+    [K in T]: 'reference'
+  }>
+}) {
+  const background = widget.get(attribute)
+  if (!background) return null
+
+  const classNames = ['img-background']
+  if (className) classNames.push(className)
+
+  if (background.contentType().startsWith('video/')) {
+    return (
+      <video
+        autoPlay
+        className={classNames.join(' ')}
+        key={background.contentUrl()}
+        loop
+        muted
+        playsInline
+        src={background.contentUrl()}
+      />
+    )
+  }
+
+  return (
+    <InPlaceEditingOff>
+      <ImageTag
+        content={widget}
+        attribute={attribute}
+        className={classNames.join(' ')}
+        alt=""
+      />
+    </InPlaceEditingOff>
+  )
+})

--- a/src/Widgets/CardWidget/CardWidgetClass.ts
+++ b/src/Widgets/CardWidget/CardWidgetClass.ts
@@ -36,9 +36,3 @@ export const CardWidget = provideWidgetClass('CardWidget', {
   },
   extractTextAttributes: ['cardBody', 'cardFooter'],
 })
-
-export type CardWidgetInstance = InstanceType<typeof CardWidget>
-
-export function isCardWidget(input: unknown): input is CardWidgetInstance {
-  return input instanceof CardWidget
-}

--- a/src/Widgets/CardWidget/CardWidgetClass.ts
+++ b/src/Widgets/CardWidget/CardWidgetClass.ts
@@ -21,7 +21,7 @@ export const CardWidget = provideWidgetClass('CardWidget', {
         ],
       },
     ],
-    backgroundImage: ['reference', { only: ['Image'] }],
+    backgroundImage: ['reference', { only: ['Image', 'Video'] }],
     cardBody: 'widgetlist',
     cardExtended: 'boolean',
     cardFooter: 'widgetlist',
@@ -36,3 +36,9 @@ export const CardWidget = provideWidgetClass('CardWidget', {
   },
   extractTextAttributes: ['cardBody', 'cardFooter'],
 })
+
+export type CardWidgetInstance = InstanceType<typeof CardWidget>
+
+export function isCardWidget(input: unknown): input is CardWidgetInstance {
+  return input instanceof CardWidget
+}

--- a/src/Widgets/CardWidget/CardWidgetComponent.tsx
+++ b/src/Widgets/CardWidget/CardWidgetComponent.tsx
@@ -8,8 +8,9 @@ import {
   Link,
   LinkTag,
   isInPlaceEditingActive,
+  Widget,
 } from 'scrivito'
-import { CardWidget, CardWidgetInstance } from './CardWidgetClass'
+import { CardWidget } from './CardWidgetClass'
 import { alternativeTextForObj } from '../../utils/alternativeTextForObj'
 
 provideComponent(CardWidget, ({ widget }) => {
@@ -30,7 +31,13 @@ provideComponent(CardWidget, ({ widget }) => {
 
   return (
     <WidgetTag className={cardClassNames.join(' ')}>
-      <ImageOrVideo widget={widget} />
+      <ImageOrVideo
+        widget={widget}
+        attribute="backgroundImage"
+        className={
+          widget.get('backgroundAnimateOnHover') ? 'img-zoom' : undefined
+        }
+      />
 
       {image && (
         <LinkOrNotTag link={widget.get('linkTo')}>
@@ -85,16 +92,20 @@ const LinkOrNotTag = connect(
   },
 )
 
-const ImageOrVideo = connect(function ImageOrVideo({
+const ImageOrVideo = connect(function ImageOrVideo<T extends string>({
+  attribute,
+  className,
   widget,
 }: {
-  widget: CardWidgetInstance
+  attribute: T
+  className?: string
+  widget: Widget<{ [K in T]: 'reference' }>
 }) {
-  const background = widget.get('backgroundImage')
+  const background = widget.get(attribute)
   if (!background) return null
 
   const classNames = ['img-background']
-  if (widget.get('backgroundAnimateOnHover')) classNames.push('img-zoom')
+  if (className) classNames.push(className)
 
   if (background.contentType().startsWith('video/')) {
     return (
@@ -114,7 +125,7 @@ const ImageOrVideo = connect(function ImageOrVideo({
     <InPlaceEditingOff>
       <ImageTag
         content={widget}
-        attribute="backgroundImage"
+        attribute={attribute}
         className={classNames.join(' ')}
         alt=""
       />

--- a/src/Widgets/CardWidget/CardWidgetComponent.tsx
+++ b/src/Widgets/CardWidget/CardWidgetComponent.tsx
@@ -8,10 +8,10 @@ import {
   Link,
   LinkTag,
   isInPlaceEditingActive,
-  Widget,
 } from 'scrivito'
 import { CardWidget } from './CardWidgetClass'
 import { alternativeTextForObj } from '../../utils/alternativeTextForObj'
+import { ImageOrVideo } from '../../Components/ImageOrVideo'
 
 provideComponent(CardWidget, ({ widget }) => {
   const cardBodyClassNames: string[] = ['card-body']
@@ -91,44 +91,3 @@ const LinkOrNotTag = connect(
     )
   },
 )
-
-const ImageOrVideo = connect(function ImageOrVideo<T extends string>({
-  attribute,
-  className,
-  widget,
-}: {
-  attribute: T
-  className?: string
-  widget: Widget<{ [K in T]: 'reference' }>
-}) {
-  const background = widget.get(attribute)
-  if (!background) return null
-
-  const classNames = ['img-background']
-  if (className) classNames.push(className)
-
-  if (background.contentType().startsWith('video/')) {
-    return (
-      <video
-        autoPlay
-        className={classNames.join(' ')}
-        key={background.contentUrl()}
-        loop
-        muted
-        playsInline
-        src={background.contentUrl()}
-      />
-    )
-  }
-
-  return (
-    <InPlaceEditingOff>
-      <ImageTag
-        content={widget}
-        attribute={attribute}
-        className={classNames.join(' ')}
-        alt=""
-      />
-    </InPlaceEditingOff>
-  )
-})

--- a/src/Widgets/CardWidget/CardWidgetComponent.tsx
+++ b/src/Widgets/CardWidget/CardWidgetComponent.tsx
@@ -9,19 +9,13 @@ import {
   LinkTag,
   isInPlaceEditingActive,
 } from 'scrivito'
-import { CardWidget } from './CardWidgetClass'
+import { CardWidget, CardWidgetInstance } from './CardWidgetClass'
 import { alternativeTextForObj } from '../../utils/alternativeTextForObj'
 
 provideComponent(CardWidget, ({ widget }) => {
   const cardBodyClassNames: string[] = ['card-body']
   const padding = widget.get('padding')
   cardBodyClassNames.push(padding ? padding : 'p-4')
-
-  const backgroundImage = widget.get('backgroundImage')
-  const backgroundImageClassNames = ['img-background']
-  if (widget.get('backgroundAnimateOnHover')) {
-    backgroundImageClassNames.push('img-zoom')
-  }
 
   const image = widget.get('image')
 
@@ -36,16 +30,7 @@ provideComponent(CardWidget, ({ widget }) => {
 
   return (
     <WidgetTag className={cardClassNames.join(' ')}>
-      {backgroundImage && (
-        <InPlaceEditingOff>
-          <ImageTag
-            content={widget}
-            attribute="backgroundImage"
-            className={backgroundImageClassNames.join(' ')}
-            alt=""
-          />
-        </InPlaceEditingOff>
-      )}
+      <ImageOrVideo widget={widget} />
 
       {image && (
         <LinkOrNotTag link={widget.get('linkTo')}>
@@ -99,3 +84,40 @@ const LinkOrNotTag = connect(
     )
   },
 )
+
+const ImageOrVideo = connect(function ImageOrVideo({
+  widget,
+}: {
+  widget: CardWidgetInstance
+}) {
+  const background = widget.get('backgroundImage')
+  if (!background) return null
+
+  const classNames = ['img-background']
+  if (widget.get('backgroundAnimateOnHover')) classNames.push('img-zoom')
+
+  if (background.contentType().startsWith('video/')) {
+    return (
+      <video
+        autoPlay
+        className={classNames.join(' ')}
+        key={background.contentUrl()}
+        loop
+        muted
+        playsInline
+        src={background.contentUrl()}
+      />
+    )
+  }
+
+  return (
+    <InPlaceEditingOff>
+      <ImageTag
+        content={widget}
+        attribute="backgroundImage"
+        className={classNames.join(' ')}
+        alt=""
+      />
+    </InPlaceEditingOff>
+  )
+})

--- a/src/Widgets/CardWidget/CardWidgetEditingConfig.ts
+++ b/src/Widgets/CardWidget/CardWidgetEditingConfig.ts
@@ -6,6 +6,10 @@ provideEditingConfig(CardWidget, {
   title: 'Card',
   thumbnail: Thumbnail,
   attributes: {
+    backgroundAnimateOnHover: {
+      title: 'Animate background on hover?',
+      description: 'Default: No',
+    },
     backgroundColor: {
       title: 'Background color',
       description: 'Default: White',
@@ -22,6 +26,9 @@ provideEditingConfig(CardWidget, {
         { value: 'warning', title: 'Warning' },
         { value: 'danger', title: 'Danger' },
       ],
+    },
+    backgroundImage: {
+      title: 'Background image or video',
     },
     image: { title: 'Top image' },
     cardExtended: {

--- a/src/Widgets/SectionWidget/SectionWidgetComponent.tsx
+++ b/src/Widgets/SectionWidget/SectionWidgetComponent.tsx
@@ -1,12 +1,6 @@
-import {
-  provideComponent,
-  ContentTag,
-  connect,
-  ImageTag,
-  InPlaceEditingOff,
-  WidgetTag,
-} from 'scrivito'
-import { SectionWidget, SectionWidgetInstance } from './SectionWidgetClass'
+import { provideComponent, ContentTag, WidgetTag } from 'scrivito'
+import { SectionWidget } from './SectionWidgetClass'
+import { ImageOrVideo } from '../../Components/ImageOrVideo'
 
 provideComponent(SectionWidget, ({ widget }) => {
   const sectionClassNames: string[] = []
@@ -28,7 +22,13 @@ provideComponent(SectionWidget, ({ widget }) => {
 
   return (
     <WidgetTag tag="section" className={sectionClassNames.join(' ')}>
-      <ImageOrVideo widget={widget} />
+      <ImageOrVideo
+        widget={widget}
+        attribute="backgroundImage"
+        className={
+          widget.get('backgroundAnimateOnHover') ? 'img-zoom' : undefined
+        }
+      />
       <ContentTag
         tag="div"
         content={widget}
@@ -36,42 +36,5 @@ provideComponent(SectionWidget, ({ widget }) => {
         attribute="content"
       />
     </WidgetTag>
-  )
-})
-
-const ImageOrVideo = connect(function ImageOrVideo({
-  widget,
-}: {
-  widget: SectionWidgetInstance
-}) {
-  const background = widget.get('backgroundImage')
-  if (!background) return null
-
-  const classNames = ['img-background']
-  if (widget.get('backgroundAnimateOnHover')) classNames.push('img-zoom')
-
-  if (background.contentType().startsWith('video/')) {
-    return (
-      <video
-        autoPlay
-        className={classNames.join(' ')}
-        key={background.contentUrl()}
-        loop
-        muted
-        playsInline
-        src={background.contentUrl()}
-      />
-    )
-  }
-
-  return (
-    <InPlaceEditingOff>
-      <ImageTag
-        content={widget}
-        attribute="backgroundImage"
-        className={classNames.join(' ')}
-        alt=""
-      />
-    </InPlaceEditingOff>
   )
 })

--- a/src/Widgets/SliderWidget/SliderWidgetComponent.tsx
+++ b/src/Widgets/SliderWidget/SliderWidgetComponent.tsx
@@ -1,16 +1,8 @@
-import {
-  connect,
-  ContentTag,
-  ImageTag,
-  InPlaceEditingOff,
-  provideComponent,
-} from 'scrivito'
+import { ContentTag, provideComponent } from 'scrivito'
 import Carousel from 'react-bootstrap/Carousel'
 import { SliderWidget } from './SliderWidgetClass'
-import {
-  SlideWidgetInstance,
-  isSlideWidgetInstance,
-} from '../SlideWidget/SlideWidgetClass'
+import { isSlideWidgetInstance } from '../SlideWidget/SlideWidgetClass'
+import { ImageOrVideo } from '../../Components/ImageOrVideo'
 import './SliderWidget.scss'
 
 provideComponent(SliderWidget, ({ widget }) => {
@@ -37,45 +29,11 @@ provideComponent(SliderWidget, ({ widget }) => {
               showControls ? 'has-controls' : '',
             ].join(' ')}
           >
-            <ImageOrVideo widget={item} />
+            <ImageOrVideo widget={item} attribute="background" />
 
             <ContentTag content={item} attribute="content" />
           </Carousel.Item>
         ))}
     </Carousel>
-  )
-})
-
-const ImageOrVideo = connect(function ImageOrVideo({
-  widget,
-}: {
-  widget: SlideWidgetInstance
-}) {
-  const background = widget.get('background')
-  if (!background) return null
-
-  if (background.contentType().startsWith('video/')) {
-    return (
-      <video
-        autoPlay
-        className="img-background"
-        key={background.contentUrl()}
-        loop
-        muted
-        playsInline
-        src={background.contentUrl()}
-      />
-    )
-  }
-
-  return (
-    <InPlaceEditingOff>
-      <ImageTag
-        content={widget}
-        attribute="background"
-        alt=""
-        className="img-background"
-      />
-    </InPlaceEditingOff>
   )
 })


### PR DESCRIPTION
Backgrounds of `CardWidget` can now also be a video:

<img width="310" height="78" alt="CardWidget with video background" src="https://github.com/user-attachments/assets/c9632408-3a31-438e-9c80-77ecf6dc8c82" />


[Concept](https://docs.google.com/document/d/1q4RqsL8alSl34ulBr2WRdOhKJMfQtz-fFnzSRXYp4fY/edit?tab=t.0#heading=h.d1qjg5rpzwfl)

Backport of https://github.com/Scrivito/scrivito-portal-app/pull/898 to `main`.