### PR TITLE
Site rounded corners only px

### DIFF
--- a/src/Components/ScrivitoExtensions/SiteBorderRadiusEditor.tsx
+++ b/src/Components/ScrivitoExtensions/SiteBorderRadiusEditor.tsx
@@ -25,7 +25,7 @@ export function SiteBorderRadiusEditor({ page }: { page: HomepageInstance }) {
             Applies to elements such as cards, buttons, and forms throughout the
             site. Set to 0 to disable rounded corners.
             <br />
-            Default: 0.5rem
+            Default: 8.5px
           </div>
         </div>
       </div>

--- a/src/Components/ScrivitoExtensions/SiteBorderRadiusEditor.tsx
+++ b/src/Components/ScrivitoExtensions/SiteBorderRadiusEditor.tsx
@@ -18,7 +18,7 @@ export function SiteBorderRadiusEditor({ page }: { page: HomepageInstance }) {
             onUpdate={(value) => page.update({ siteBorderRadius: value })}
             placeholder="1"
             readOnly={readOnly}
-            units={['rem', 'px']}
+            units={['px']}
             value={page.get('siteBorderRadius')}
           />
           <div className="scrivito_notice_body">

--- a/src/Objs/Homepage/HomepageEditingConfig.ts
+++ b/src/Objs/Homepage/HomepageEditingConfig.ts
@@ -141,7 +141,7 @@ provideEditingConfig(Homepage, {
   initialContent: {
     ...defaultPageInitialContent,
     contentFormat: 'portal-app:6',
-    siteBorderRadius: '0.5rem',
+    siteBorderRadius: '8.5px',
     siteDropShadow: true,
     siteFontBodyWeight: '500',
     siteFontHeadlineWeight: '500',

--- a/src/assets/stylesheets/index.scss
+++ b/src/assets/stylesheets/index.scss
@@ -133,7 +133,7 @@
   --bs-code-color: #d63384;
   --bs-highlight-bg: #fff3cd;
 
-  --jr-border-radius: 0.5rem;
+  --jr-border-radius: 8.5px;
   --jr-box-shadow: 0 0.375rem 1.5rem 0 rgba(140, 152, 164, 0.25);
   --jr-headline-font-family: 'Firava';
   --jr-headline-font-weight: 500;


### PR DESCRIPTION
Follow up of https://github.com/Scrivito/scrivito-portal-app/pull/900.

The [concept](https://docs.google.com/document/d/1q4RqsL8alSl34ulBr2WRdOhKJMfQtz-fFnzSRXYp4fY/edit?tab=t.0#heading=h.12d9pvcch0xk) was updated to only support `px` as a unit. This PR removes `rem` as the unit. 