### PR TITLE
Initialize new homepages with minimal content

### DIFF
--- a/src/Objs/Homepage/HomepageEditingConfig.ts
+++ b/src/Objs/Homepage/HomepageEditingConfig.ts
@@ -9,6 +9,10 @@ import {
   defaultPageValidations,
 } from '../defaultPageEditingConfig'
 import { SiteBorderRadiusEditor } from '../../Components/ScrivitoExtensions/SiteBorderRadiusEditor'
+import { TopNavigationWidget } from '../../Widgets/TopNavigationWidget/TopNavigationWidgetClass'
+import { SectionWidget } from '../../Widgets/SectionWidget/SectionWidgetClass'
+import { HeadlineWidget } from '../../Widgets/HeadlineWidget/HeadlineWidgetClass'
+import { TextWidget } from '../../Widgets/TextWidget/TextWidgetClass'
 
 provideEditingConfig(Homepage, {
   title: 'Homepage',
@@ -137,7 +141,15 @@ provideEditingConfig(Homepage, {
   properties: [...defaultPageProperties],
   initialContent: {
     ...defaultPageInitialContent,
+    body: [
+      new SectionWidget({
+        backgroundColor: 'primary',
+        content: [new HeadlineWidget(), new TextWidget()],
+      }),
+    ],
     contentFormat: 'portal-app:6',
+    layoutHeader: [new TopNavigationWidget()],
+    layoutShowHeader: true,
     siteBorderRadius: '8.5px',
     siteDropShadow: true,
     siteFontBodyWeight: '500',

--- a/src/assets/stylesheets/index.scss
+++ b/src/assets/stylesheets/index.scss
@@ -1302,6 +1302,10 @@ section.bg-primary {
   box-shadow: var(--jr-box-shadow);
   align-self: stretch;
   display: flex;
+
+  &:empty {
+    min-width: 100px;
+  }
 }
 
 .navbar-brand-logo {


### PR DESCRIPTION
@agessler I took the liberty to widen the panic flap (as long as no logo has been set):

| Before | After |
| -- | -- |
|  <img width="1042" height="514" alt="image" src="https://github.com/user-attachments/assets/8d4c9f2f-7b54-44b6-a078-2a2bbe743885" /> |  <img width="1042" height="514" alt="image" src="https://github.com/user-attachments/assets/ce982250-76ca-4249-86f4-44a6efcdc000" />|