### PR TITLE
Don't show "not found" if a site is present

### DIFF
--- a/src/Components/NotFoundErrorPage.tsx
+++ b/src/Components/NotFoundErrorPage.tsx
@@ -2,6 +2,7 @@ import { useEffect } from 'react'
 import {
   connect,
   ContentTag,
+  currentSiteId,
   isEditorLoggedIn,
   isUserLoggedIn,
   load,
@@ -17,6 +18,7 @@ export const NotFoundErrorPage = connect(
   function NotFoundErrorPage() {
     if (
       isUserLoggedIn() &&
+      !currentSiteId() &&
       !Obj.onAllSites().get(import.meta.env.SCRIVITO_ROOT_OBJ_ID)
     ) {
       return <NotFound />


### PR DESCRIPTION
The logic is now in sync with `ensureSiteIsPresent()`

Reported here: https://infopark.slack.com/archives/G011EJEGKD5/p1755725284652089