### PR TITLE
[blobToBinary] Bugfix - allow octet-stream base64 strings

### DIFF
--- a/src/utils/blobToBinary.ts
+++ b/src/utils/blobToBinary.ts
@@ -50,7 +50,7 @@ async function blobToBase64(blob: Blob): Promise<string> {
       }
 
       const parts = dataUrl.split(';base64,')
-      const [_firstPart, secondPart, ...rest] = parts
+      const [, secondPart, ...rest] = parts
       if (!secondPart || rest.length > 0) {
         reject(
           new Error(


### PR DESCRIPTION
Sometimes the prefix of dataUrl of the FileReader output, does not match `blob.type`. In this case it is better to allow the generic mime type `application/octet-stream` instead.

Fixes https://app.honeybadger.io/projects/132043/faults/123009878.