### PR TITLE
Replace SCRIVITO_ROOT_OBJ_ID with SCRIVITO_DEFAULT_CONTENT_ID

### DIFF
--- a/src/Components/NotFoundErrorPage.tsx
+++ b/src/Components/NotFoundErrorPage.tsx
@@ -10,17 +10,14 @@ import {
   NotFoundErrorPage as ScrivitoNotFoundErrorPage,
 } from 'scrivito'
 import { Loading } from './Loading'
+import { defaultSites } from '../multiSite/defaultSites'
 
 // Make sure, that you have a proxy running for these URLs, otherwise you'll see an endless loop.
 const RELOAD_SUBPATHS = ['/auth']
 
 export const NotFoundErrorPage = connect(
   function NotFoundErrorPage() {
-    if (
-      isUserLoggedIn() &&
-      !currentSiteId() &&
-      !Obj.onAllSites().get(import.meta.env.SCRIVITO_ROOT_OBJ_ID)
-    ) {
+    if (isUserLoggedIn() && !currentSiteId() && !defaultSites().take(1)) {
       return <NotFound />
     }
 

--- a/src/Data/jwtPisaSalesApiConfig.ts
+++ b/src/Data/jwtPisaSalesApiConfig.ts
@@ -1,7 +1,9 @@
 import type { ApiClientOptions } from 'scrivito'
-import { currentLanguage, load, Obj } from 'scrivito'
+import { currentLanguage, load } from 'scrivito'
+import { orderBy } from 'lodash-es'
 import { isHomepage } from '../Objs/Homepage/HomepageObjClass'
 import { getTokenAuthorization } from './getTokenAuthorization'
+import { defaultSites } from '../multiSite/defaultSites'
 
 export async function jwtPisaSalesApiConfig({
   subPath,
@@ -23,13 +25,31 @@ export async function jwtPisaSalesApiConfig({
   }
 }
 
+export function jwtPisaSalesConfigSite() {
+  const preferences = ['en', 'de', 'fr', 'pl']
+
+  const sortedSites = orderBy(
+    defaultSites().toArray(),
+    [
+      (obj) => {
+        const lang = obj.language()
+        const index = lang ? preferences.indexOf(lang) : -1
+        return index === -1 ? preferences.length : index
+      },
+      (obj) => obj.createdAt(),
+      (obj) => obj.id(),
+    ],
+    ['asc', 'asc', 'asc'],
+  )
+
+  return sortedSites[0]
+}
+
 async function jwtPisaSalesApiUrl(): Promise<string | null> {
   if (import.meta.env.FORCE_LOCAL_STORAGE) return null
 
-  const defaultRoot = await load(() =>
-    Obj.onAllSites().get(import.meta.env.SCRIVITO_ROOT_OBJ_ID),
-  )
-  if (!isHomepage(defaultRoot)) return null
+  const root = await load(() => jwtPisaSalesConfigSite())
+  if (!isHomepage(root)) return null
 
-  return defaultRoot.get('jwtPisaSalesApiUrl') || null
+  return root.get('jwtPisaSalesApiUrl') || null
 }

--- a/src/Objs/Homepage/HomepageEditingConfig.ts
+++ b/src/Objs/Homepage/HomepageEditingConfig.ts
@@ -13,6 +13,7 @@ import { TopNavigationWidget } from '../../Widgets/TopNavigationWidget/TopNaviga
 import { SectionWidget } from '../../Widgets/SectionWidget/SectionWidgetClass'
 import { HeadlineWidget } from '../../Widgets/HeadlineWidget/HeadlineWidgetClass'
 import { TextWidget } from '../../Widgets/TextWidget/TextWidgetClass'
+import { jwtPisaSalesConfigSite } from '../../Data/jwtPisaSalesApiConfig'
 
 provideEditingConfig(Homepage, {
   title: 'Homepage',
@@ -91,7 +92,7 @@ provideEditingConfig(Homepage, {
       properties: [
         'contentTitle',
         'baseUrl',
-        site.id() === import.meta.env.SCRIVITO_ROOT_OBJ_ID
+        site.id() === jwtPisaSalesConfigSite()?.id()
           ? 'jwtPisaSalesApiUrl'
           : null,
         'siteLogoDark',

--- a/src/config/scrivitoSites.ts
+++ b/src/config/scrivitoSites.ts
@@ -13,7 +13,7 @@ export function baseUrlForSite(siteId: string): string | undefined {
   const siteRoot = Obj.onSite(siteId).root()
   if (!siteRoot) return
 
-  if (siteRoot.contentId() !== defaultSiteContentId()) {
+  if (siteRoot.contentId() !== import.meta.env.SCRIVITO_DEFAULT_CONTENT_ID) {
     const configuredBaseUrl = configuredBaseUrlsFor(siteRoot)[0]
     if (configuredBaseUrl) return configuredBaseUrl
   }
@@ -58,9 +58,9 @@ function findSiteByUrl(url: string) {
   const { contentId: urlContentId, language } = extractFromUrl(url)
   if (!language) return {}
 
-  if (urlContentId === defaultSiteContentId()) return {}
+  if (urlContentId === import.meta.env.SCRIVITO_DEFAULT_CONTENT_ID) return {}
 
-  const contentId = urlContentId || defaultSiteContentId()
+  const contentId = urlContentId || import.meta.env.SCRIVITO_DEFAULT_CONTENT_ID
   if (!contentId) return {}
 
   const siteId = findSiteIdBy({ contentId, language })
@@ -111,13 +111,7 @@ function configuredBaseUrlsFor(site: Obj) {
 
 function baseUrlFor(language: string, contentId?: string) {
   const base = instanceBaseUrl()
-  return contentId && contentId !== defaultSiteContentId()
+  return contentId && contentId !== import.meta.env.SCRIVITO_DEFAULT_CONTENT_ID
     ? `${base}/${contentId}/${language}`
     : `${base}/${language}`
-}
-
-function defaultSiteContentId() {
-  return Obj.onAllSites()
-    .get(import.meta.env.SCRIVITO_ROOT_OBJ_ID)
-    ?.contentId()
 }

--- a/src/multiSite/defaultSites.ts
+++ b/src/multiSite/defaultSites.ts
@@ -1,0 +1,8 @@
+import { Obj } from 'scrivito'
+
+export function defaultSites() {
+  return Obj.onAllSites()
+    .where('_path', 'equals', '/')
+    .and('_contentId', 'equals', import.meta.env.SCRIVITO_DEFAULT_CONTENT_ID)
+    .andNot('_siteId', 'equals', null)
+}

--- a/src/multiSite/ensureSiteIsPresent.ts
+++ b/src/multiSite/ensureSiteIsPresent.ts
@@ -6,15 +6,12 @@ import {
   urlFor,
 } from 'scrivito'
 import { extractFromUrl } from './extractFromUrl'
+import { defaultSites } from './defaultSites'
 
 export async function ensureSiteIsPresent() {
   if (await load(() => currentSiteId())) return
 
-  if (
-    await load(
-      () => !Obj.onAllSites().get(import.meta.env.SCRIVITO_ROOT_OBJ_ID),
-    )
-  ) {
+  if (await load(() => !defaultSites().toArray().length)) {
     ensureUserIsLoggedIn()
     return
   }
@@ -67,9 +64,9 @@ function getLanguageVersions(contentId?: string): Obj[] | undefined {
         .toArray()[0]
     : undefined
 
-  return (
-    root || Obj.onAllSites().get(import.meta.env.SCRIVITO_ROOT_OBJ_ID)
-  )?.versionsOnAllSites()
+  if (root) return root.versionsOnAllSites()
+
+  return defaultSites().toArray()
 }
 
 function siteHasLanguage(site: Obj, language: string | null) {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -61,6 +61,9 @@ export default defineConfig(({ mode }) => {
       sourcemap: !!HONEYBADGER_API_KEY,
     },
     define: {
+      'import.meta.env.SCRIVITO_DEFAULT_CONTENT_ID': JSON.stringify(
+        env.SCRIVITO_DEFAULT_CONTENT_ID || 'c2a0aab78be05a4e',
+      ),
       'import.meta.env.SCRIVITO_ORIGIN': JSON.stringify(scrivitoOrigin(env)),
       'import.meta.env.SCRIVITO_TENANT': JSON.stringify(env.SCRIVITO_TENANT),
       'import.meta.env.SCRIVITO_ROOT_OBJ_ID': JSON.stringify(

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -66,9 +66,6 @@ export default defineConfig(({ mode }) => {
       ),
       'import.meta.env.SCRIVITO_ORIGIN': JSON.stringify(scrivitoOrigin(env)),
       'import.meta.env.SCRIVITO_TENANT': JSON.stringify(env.SCRIVITO_TENANT),
-      'import.meta.env.SCRIVITO_ROOT_OBJ_ID': JSON.stringify(
-        env.SCRIVITO_ROOT_OBJ_ID || 'c2a0aab78be05a4e',
-      ),
       'import.meta.env.HONEYBADGER_API_KEY':
         JSON.stringify(HONEYBADGER_API_KEY),
       'import.meta.env.HONEYBADGER_ENVIRONMENT': JSON.stringify(


### PR DESCRIPTION
Motivation: Currently the setup relies on a "magic obj ID". When this obj is existing all is good, but as soon as this obj is deleted we would have to document created a specific Obj with a specific `_id`. Instead one now has to "only" set a special `_contentId` for the root obj.

So https://docs.scrivito.com/js-sdk-cheat-sheet#deleting-all-website-content would look like this _after_ this PR:

```
// objs = await ...

Scrivito.getClass("Homepage").create({
  _path: "/",
  _language: "en",
  _contentId: "c2a0aab78be05a4e",
});

// objs.forEach((o) => { ...
```