### PR TITLE
http-proxy-agent: Force update of @tootallnate/once

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3403,9 +3403,9 @@
       }
     },
     "node_modules/@tootallnate/once": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
-      "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-3.0.1.tgz",
+      "integrity": "sha512-VyMVKRrpHTT8PnotUeV8L/mDaMwD5DaAKCFLP73zAqAtvF0FCqky+Ki7BYbFCYQmqFyTe9316Ed5zS70QUR9eg==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "vite-node": "^6.0.0"
   },
   "overrides": {
+    "@tootallnate/once": "^3.0.1",
     "@lhci/cli": {
       "cookie": "^0.7.0",
       "rimraf": "4",


### PR DESCRIPTION
Please note, that there are several versions of http-proxy-agent in use (7.0.2 and 5.0.0), but only version 5.0.0 uses "@tootallnate/once". I tried to scope the overwrite to `http-proxy-agent@5` and `http-proxy-agent@5.0.0`, but npm (version 11.12.1) had trouble to follow the instruction correctly.

Fixes https://github.com/Scrivito/scrivito-portal-app/security/dependabot/60.