### PR TITLE
Tailwind: Specify exact version

### DIFF
--- a/.knip.jsonc
+++ b/.knip.jsonc
@@ -18,6 +18,7 @@
   "ignoreBinaries": ["break"], // Lighthouse false positive
   "ignoreDependencies": [
     "@cloudflare/workers-types", // used by functions/*
+    "tailwindcss", // used by @tailwindcss/vite
 
     // used by eslint.config.mjs; Workaround for https://github.com/webpro-nl/knip/issues/818
     "@arabasta/eslint-plugin-react",

--- a/package-lock.json
+++ b/package-lock.json
@@ -59,6 +59,7 @@
         "prettier": "^3.8.3",
         "prettier-plugin-tailwindcss": "^0.0.0-insiders.f7d2598",
         "sass": "^1.78.0",
+        "tailwindcss": "4.2.2",
         "typescript": "^5.9.3",
         "vite": "^7.3.1",
         "vite-node": "^6.0.0"

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "prettier": "^3.8.3",
     "prettier-plugin-tailwindcss": "^0.0.0-insiders.f7d2598",
     "sass": "^1.78.0",
+    "tailwindcss": "4.2.2",
     "typescript": "^5.9.3",
     "vite": "^7.3.1",
     "vite-node": "^6.0.0"


### PR DESCRIPTION
This will enable e.g. dependabot to look for updates. Previously it was only a sub-dependency of "@tailwindcss/vite".

Please note, that "@tailwindcss/vite" currently has an exact version number dependency.