### PR TITLE
npm: No longer override @tootallnate/once

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3404,9 +3404,9 @@
       }
     },
     "node_modules/@tootallnate/once": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-3.0.1.tgz",
-      "integrity": "sha512-VyMVKRrpHTT8PnotUeV8L/mDaMwD5DaAKCFLP73zAqAtvF0FCqky+Ki7BYbFCYQmqFyTe9316Ed5zS70QUR9eg==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.1.tgz",
+      "integrity": "sha512-HqmEUIGRJ5fSXchkVgR5F7qn48bDBzv0kWj/Kfu5e6uci4UlEeng4331LnBkWffb++Ei3FOVLxo8JJWMFBDMeQ==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -76,7 +76,6 @@
     "vite-node": "^6.0.0"
   },
   "overrides": {
-    "@tootallnate/once": "^3.0.1",
     "@lhci/cli": {
       "cookie": "^0.7.0",
       "rimraf": "4",


### PR DESCRIPTION
Thankfully there is now a bugfix for version 2 available. See https://github.com/TooTallNate/once/issues/11#issuecomment-4366821438