### PR TITLE
Convert contentDump/index.json to new objs manifest format

### DIFF
--- a/contentDump/index.json
+++ b/contentDump/index.json
@@ -1,190 +1,1004 @@
 {
-  "objIds": [
-    "fec151165aeb27da",
-    "fd573c40f9c733ef",
-    "fd456e1a38e85cfb",
-    "fcfbdded110d9f59",
-    "fb302b23c46fea41",
-    "fb161c52690aeb71",
-    "fa725f0b47fdc408",
-    "f909e9691db27360",
-    "f7da3de531e46fe9",
-    "f70ac27424b4ba20",
-    "f6f521cad64ae778",
-    "f688f1b1b19451ae",
-    "f5993d6de3609ac0",
-    "f35e3741a5662ea5",
-    "f26e8a78bafd4b51",
-    "f16dc0fbeddfaa9f",
-    "f0724ea2d31beeee",
-    "efb46cb2c7fa3cb5",
-    "ef1affd741c972ae",
-    "ed043d1606eaf539",
-    "ec9a22125e28ddcc",
-    "eaef667ca661db87",
-    "e9c7e3b53f1b84f8",
-    "e94896f45d8b5699",
-    "e8f5370d6569478a",
-    "e842f873009bceb2",
-    "e7118807488a6364",
-    "e6f438cec91e8b70",
-    "e57bd020bc65ca3f",
-    "e3dd81b9fab74d4f",
-    "df208b86b908e06d",
-    "dead12c1e1d922fc",
-    "dce8a41ef712a33c",
-    "dae0df2517e9f6c6",
-    "d9d4a49fab05294e",
-    "d7cb8d71df8ef049",
-    "d54072c39c8ad493",
-    "d4967853cd3565f8",
-    "d11017df5d1aaf49",
-    "cf272458e84506fc",
-    "cd31e0242dedcfa8",
-    "cc7f4ee9650cc196",
-    "cbf7a8181975c0b2",
-    "cb4df3bce5e37dd3",
-    "c90eea51a835c4f8",
-    "c74f1a8c820fd90c",
-    "c57ed6048b05e7d8",
-    "c3570e788bbaf414",
-    "c2a0aab78be05a4e",
-    "c282f3e5cd6edd64",
-    "c1bcb692f44e9b9d",
-    "bf0854ff801edf64",
-    "bdbb81709c5e1c63",
-    "bd53fa4ef38c1c40",
-    "ba523240594af65b",
-    "b85ac625f1ab9db3",
-    "b6307ad8551faa98",
-    "b4cc4694ca6c328d",
-    "b084080e1fd4de8c",
-    "ac69610ed785849f",
-    "ab2921d83b66edb5",
-    "a95b99e0c7614110",
-    "a8ede3121df9e2f6",
-    "a6417ce55f02f243",
-    "a593db912c64b615",
-    "a4e3f5b83f51996e",
-    "a21465ccaa9eb97b",
-    "a212a3739b74db01",
-    "a06b1df4da698269",
-    "9dd6d1b926a6bbc6",
-    "9db36de70dd4d157",
-    "9d0a44c21cfbfae0",
-    "9a601c5b409e510d",
-    "997a69894cd7fb2a",
-    "97c5809a3b2286f0",
-    "96657d14578333ce",
-    "93ed03e1af1c242d",
-    "8d6e2ff3001b9a03",
-    "89494e7dcdff932b",
-    "8942b689824112e6",
-    "888338d8ca9cb8da",
-    "8764987d24e806f3",
-    "86e7f2cb286063a6",
-    "8652bdd9640b1c9b",
-    "84435b45662730da",
-    "8252c6d5cff8c608",
-    "81ebb90e42af884b",
-    "7f5d7c4c3879174f",
-    "7e68ab76a338b481",
-    "7daec637e1d07ef1",
-    "7cdeea74355996a1",
-    "7c7ec6527e37a00c",
-    "7c793651bfd5b099",
-    "7bc07003a4e4960a",
-    "7b2f9815fd86158b",
-    "7aa779f9fcf90589",
-    "7909f54fc49b2b38",
-    "78d7aebb7ca0aa3b",
-    "78d1e6ccd971faf3",
-    "75f5feaca1004671",
-    "7524eb15818546b7",
-    "749ee4e15707e4ff",
-    "71ec0827969c2bd8",
-    "70f1003260d74f46",
-    "70774feb6aba40dc",
-    "6eff94f91196a7d4",
-    "6c31d6fed5dc2915",
-    "6b7384cb6c929947",
-    "6a5898770a646824",
-    "69a8e80928a60aa4",
-    "67cd8e40499996e0",
-    "66e88191d1265340",
-    "648a0682c458d492",
-    "6120bc3f0037c125",
-    "60ee30e12429563b",
-    "5fd98ea58bd33f5f",
-    "5ea4d48ed6e829a7",
-    "5e4bdb0a09991e19",
-    "5c00595a07768f9d",
-    "5bf9b4a48a5031e3",
-    "5b3756546b7462ba",
-    "59274260f223b65f",
-    "54de6e5acebb5566",
-    "53cdc93aeaeabc4b",
-    "52c8212b3ff23e55",
-    "52311cd4fb7fce3b",
-    "518864722dad1deb",
-    "4f4d221b9e654c82",
-    "4d9d13338d36a696",
-    "4b188044778bdb6e",
-    "4af8d0714f0faad1",
-    "486f8f791abc7a5f",
-    "471f4f107fd0d6d2",
-    "437fc8fecb7440f7",
-    "41bff0c5d0d381c0",
-    "410885f6410a0e68",
-    "40fcff128372c95a",
-    "3fda98a107e6ae1a",
-    "3f4d1ebe4e291e04",
-    "3e782832e1504ecd",
-    "3a4cd2a0a23cea9b",
-    "38d52d38e1f73575",
-    "32954debcdfee6a3",
-    "31f54bc713bc6050",
-    "2f5fe2e900e4ce8b",
-    "2e9f2e07aeab717e",
-    "2e44384af30acbc8",
-    "2de7f41f5b80e6ab",
-    "2d2269d9b701ac2d",
-    "2ab32827eeeebef7",
-    "2a57d2bf1a87afda",
-    "2a54d41a981a2ab4",
-    "29bd97232006ec75",
-    "29b1bd22ef98b074",
-    "29580917605abc9c",
-    "28a187fa9ff2d6c2",
-    "28409ab9b03e36b4",
-    "28387df3419314b8",
-    "281600edb8b95202",
-    "26d2c9ef30130477",
-    "2484166e90949b32",
-    "22d9c6805af643eb",
-    "202e29af7f62a739",
-    "1f6fc8477eeb0862",
-    "1f555d6a877a7662",
-    "1e241bae572507e8",
-    "19fa35572ff3975c",
-    "162a0a7e8f6d87d1",
-    "14c0a6ebac3c6e7b",
-    "1481d0454ec9a8eb",
-    "140dc93f827a36a4",
-    "1409db9bede134fb",
-    "13c793bd134405d4",
-    "125f0003cf11c725",
-    "11a20e6047134560",
-    "0e84d1e469f7cfac",
-    "0e0e03ae10d47eee",
-    "0dda554dfe67da45",
-    "09a152b36247dc0a",
-    "060918d8e44ae54f",
-    "0513c02cb152a069",
-    "046cc19cf0f87d9d",
-    "03cd0d7704a1195a",
-    "02d09ad2dd7d2332",
-    "027be0e907d46d8e",
-    "0092ff67875b69f8"
+  "objs": [
+    {
+      "id": "fec151165aeb27da",
+      "siteId": "56a14d0750cc844e",
+      "contentId": "fec151165aeb27da",
+      "path": "/33cbdf671c7b83b1/3cc07265490102de"
+    },
+    {
+      "id": "fd573c40f9c733ef",
+      "siteId": "696dde5f0b15a227",
+      "contentId": "fd573c40f9c733ef"
+    },
+    {
+      "id": "fd456e1a38e85cfb",
+      "contentId": "fd456e1a38e85cfb"
+    },
+    {
+      "id": "fcfbdded110d9f59",
+      "contentId": "fcfbdded110d9f59"
+    },
+    {
+      "id": "fb302b23c46fea41",
+      "siteId": "56a14d0750cc844e",
+      "contentId": "fb302b23c46fea41",
+      "path": "/33cbdf671c7b83b1/edd1e72884bf7d89/7516c8021fa03851"
+    },
+    {
+      "id": "fb161c52690aeb71",
+      "siteId": "56a14d0750cc844e",
+      "contentId": "fb161c52690aeb71",
+      "path": "/33cbdf671c7b83b1/edd1e72884bf7d89/2ab32827eeeebef7/fb161c52690aeb71"
+    },
+    {
+      "id": "fa725f0b47fdc408",
+      "siteId": "56a14d0750cc844e",
+      "contentId": "fa725f0b47fdc408",
+      "path": "/587d96465c3c69c4/fa725f0b47fdc408"
+    },
+    {
+      "id": "f909e9691db27360",
+      "siteId": "56a14d0750cc844e",
+      "contentId": "f909e9691db27360",
+      "path": "/33cbdf671c7b83b1/edd1e72884bf7d89/125f0003cf11c725/f909e9691db27360"
+    },
+    {
+      "id": "f7da3de531e46fe9",
+      "siteId": "56a14d0750cc844e",
+      "contentId": "f7da3de531e46fe9",
+      "path": "/33cbdf671c7b83b1/edd1e72884bf7d89/f7da3de531e46fe9"
+    },
+    {
+      "id": "f70ac27424b4ba20",
+      "siteId": "dc07b5fb5abd4c35",
+      "contentId": "70f1003260d74f46",
+      "path": "/f70ac27424b4ba20"
+    },
+    {
+      "id": "f6f521cad64ae778",
+      "contentId": "f6f521cad64ae778"
+    },
+    {
+      "id": "f688f1b1b19451ae",
+      "siteId": "dc07b5fb5abd4c35",
+      "contentId": "38d52d38e1f73575",
+      "path": "/1f555d6a877a7662/f688f1b1b19451ae"
+    },
+    {
+      "id": "f5993d6de3609ac0",
+      "siteId": "56a14d0750cc844e",
+      "contentId": "f5993d6de3609ac0",
+      "path": "/35aa421c76a38f87"
+    },
+    {
+      "id": "f35e3741a5662ea5",
+      "siteId": "56a14d0750cc844e",
+      "contentId": "f35e3741a5662ea5",
+      "path": "/587d96465c3c69c4/7a141950d1520c28/574d560204cebf08"
+    },
+    {
+      "id": "f26e8a78bafd4b51",
+      "contentId": "f26e8a78bafd4b51"
+    },
+    {
+      "id": "f16dc0fbeddfaa9f",
+      "siteId": "dc07b5fb5abd4c35",
+      "contentId": "f7da3de531e46fe9",
+      "path": "/84435b45662730da/bd53fa4ef38c1c40/f16dc0fbeddfaa9f"
+    },
+    {
+      "id": "f0724ea2d31beeee",
+      "siteId": "56a14d0750cc844e",
+      "contentId": "f0724ea2d31beeee",
+      "path": "/33cbdf671c7b83b1"
+    },
+    {
+      "id": "efb46cb2c7fa3cb5",
+      "contentId": "efb46cb2c7fa3cb5"
+    },
+    {
+      "id": "ef1affd741c972ae",
+      "siteId": "696dde5f0b15a227",
+      "contentId": "ef1affd741c972ae"
+    },
+    {
+      "id": "ed043d1606eaf539",
+      "siteId": "dc07b5fb5abd4c35",
+      "contentId": "749ee4e15707e4ff",
+      "path": "/ed043d1606eaf539"
+    },
+    {
+      "id": "ec9a22125e28ddcc",
+      "siteId": "56a14d0750cc844e",
+      "contentId": "ec9a22125e28ddcc",
+      "path": "/33cbdf671c7b83b1/edd1e72884bf7d89/f7da3de531e46fe9/ec9a22125e28ddcc"
+    },
+    {
+      "id": "eaef667ca661db87",
+      "contentId": "eaef667ca661db87"
+    },
+    {
+      "id": "e9c7e3b53f1b84f8",
+      "siteId": "dc07b5fb5abd4c35",
+      "contentId": "28409ab9b03e36b4",
+      "path": "/ed043d1606eaf539/41bff0c5d0d381c0/e9c7e3b53f1b84f8"
+    },
+    {
+      "id": "e94896f45d8b5699",
+      "siteId": "56a14d0750cc844e",
+      "contentId": "e94896f45d8b5699",
+      "path": "/33cbdf671c7b83b1/edd1e72884bf7d89/046cc19cf0f87d9d/1e241bae572507e8/e94896f45d8b5699"
+    },
+    {
+      "id": "e8f5370d6569478a",
+      "siteId": "56a14d0750cc844e",
+      "contentId": "e8f5370d6569478a",
+      "path": "/33cbdf671c7b83b1/edd1e72884bf7d89/4df09188b1541b70/e8f5370d6569478a"
+    },
+    {
+      "id": "e842f873009bceb2",
+      "siteId": "56a14d0750cc844e",
+      "contentId": "e842f873009bceb2",
+      "path": "/33cbdf671c7b83b1/edd1e72884bf7d89/4df09188b1541b70/606699b3b1e3d6ae"
+    },
+    {
+      "id": "e7118807488a6364",
+      "siteId": "56a14d0750cc844e",
+      "contentId": "e7118807488a6364",
+      "path": "/33cbdf671c7b83b1/edd1e72884bf7d89/125f0003cf11c725/e7118807488a6364"
+    },
+    {
+      "id": "e6f438cec91e8b70",
+      "siteId": "dc07b5fb5abd4c35",
+      "contentId": "d9d4a49fab05294e",
+      "path": "/1f555d6a877a7662/e6f438cec91e8b70"
+    },
+    {
+      "id": "e57bd020bc65ca3f",
+      "siteId": "dc07b5fb5abd4c35",
+      "contentId": "e57bd020bc65ca3f",
+      "path": "/ed043d1606eaf539/e57bd020bc65ca3f"
+    },
+    {
+      "id": "e3dd81b9fab74d4f",
+      "siteId": "dc07b5fb5abd4c35",
+      "contentId": "e3dd81b9fab74d4f"
+    },
+    {
+      "id": "df208b86b908e06d",
+      "siteId": "dc07b5fb5abd4c35",
+      "contentId": "28718c1fe9dd5169",
+      "path": "/6a5898770a646824/df208b86b908e06d"
+    },
+    {
+      "id": "dead12c1e1d922fc",
+      "contentId": "dead12c1e1d922fc"
+    },
+    {
+      "id": "dce8a41ef712a33c",
+      "siteId": "dc07b5fb5abd4c35",
+      "contentId": "f35e3741a5662ea5",
+      "path": "/ed043d1606eaf539/5c00595a07768f9d/dce8a41ef712a33c"
+    },
+    {
+      "id": "dae0df2517e9f6c6",
+      "siteId": "dc07b5fb5abd4c35",
+      "contentId": "70774feb6aba40dc",
+      "path": "/ed043d1606eaf539/2e9f2e07aeab717e/dae0df2517e9f6c6"
+    },
+    {
+      "id": "d9d4a49fab05294e",
+      "siteId": "56a14d0750cc844e",
+      "contentId": "d9d4a49fab05294e",
+      "path": "/55d682c23b93bd62/d9d4a49fab05294e"
+    },
+    {
+      "id": "d7cb8d71df8ef049",
+      "contentId": "d7cb8d71df8ef049"
+    },
+    {
+      "id": "d54072c39c8ad493",
+      "siteId": "dc07b5fb5abd4c35",
+      "contentId": "2ab32827eeeebef7",
+      "path": "/84435b45662730da/bd53fa4ef38c1c40/d54072c39c8ad493"
+    },
+    {
+      "id": "d4967853cd3565f8",
+      "siteId": "dc07b5fb5abd4c35",
+      "contentId": "8942b689824112e6",
+      "path": "/1f555d6a877a7662/d4967853cd3565f8"
+    },
+    {
+      "id": "d11017df5d1aaf49",
+      "siteId": "dc07b5fb5abd4c35",
+      "contentId": "3a4cd2a0a23cea9b",
+      "path": "/84435b45662730da/d11017df5d1aaf49"
+    },
+    {
+      "id": "cf272458e84506fc",
+      "siteId": "696dde5f0b15a227",
+      "contentId": "cf272458e84506fc"
+    },
+    {
+      "id": "cd31e0242dedcfa8",
+      "siteId": "56a14d0750cc844e",
+      "contentId": "cd31e0242dedcfa8",
+      "path": "/33cbdf671c7b83b1/bfc7deb2d5d4425f/cd31e0242dedcfa8"
+    },
+    {
+      "id": "cc7f4ee9650cc196",
+      "contentId": "cc7f4ee9650cc196"
+    },
+    {
+      "id": "cbf7a8181975c0b2",
+      "contentId": "cbf7a8181975c0b2"
+    },
+    {
+      "id": "cb4df3bce5e37dd3",
+      "siteId": "dc07b5fb5abd4c35",
+      "contentId": "a8ede3121df9e2f6",
+      "path": "/ed043d1606eaf539/cb4df3bce5e37dd3"
+    },
+    {
+      "id": "c90eea51a835c4f8",
+      "contentId": "c90eea51a835c4f8"
+    },
+    {
+      "id": "c74f1a8c820fd90c",
+      "siteId": "696dde5f0b15a227",
+      "contentId": "c74f1a8c820fd90c"
+    },
+    {
+      "id": "c57ed6048b05e7d8",
+      "contentId": "c57ed6048b05e7d8"
+    },
+    {
+      "id": "c3570e788bbaf414",
+      "contentId": "c3570e788bbaf414"
+    },
+    {
+      "id": "c2a0aab78be05a4e",
+      "siteId": "56a14d0750cc844e",
+      "contentId": "c2a0aab78be05a4e",
+      "path": "/"
+    },
+    {
+      "id": "c282f3e5cd6edd64",
+      "contentId": "c282f3e5cd6edd64"
+    },
+    {
+      "id": "c1bcb692f44e9b9d",
+      "contentId": "c1bcb692f44e9b9d"
+    },
+    {
+      "id": "bf0854ff801edf64",
+      "siteId": "696dde5f0b15a227",
+      "contentId": "bf0854ff801edf64"
+    },
+    {
+      "id": "bdbb81709c5e1c63",
+      "siteId": "dc07b5fb5abd4c35",
+      "contentId": "c2a0aab78be05a4e",
+      "path": "/"
+    },
+    {
+      "id": "bd53fa4ef38c1c40",
+      "siteId": "dc07b5fb5abd4c35",
+      "contentId": "59274260f223b65f",
+      "path": "/84435b45662730da/bd53fa4ef38c1c40"
+    },
+    {
+      "id": "ba523240594af65b",
+      "siteId": "696dde5f0b15a227",
+      "contentId": "ba523240594af65b"
+    },
+    {
+      "id": "b85ac625f1ab9db3",
+      "siteId": "dc07b5fb5abd4c35",
+      "contentId": "125f0003cf11c725",
+      "path": "/84435b45662730da/bd53fa4ef38c1c40/b85ac625f1ab9db3"
+    },
+    {
+      "id": "b6307ad8551faa98",
+      "contentId": "b6307ad8551faa98"
+    },
+    {
+      "id": "b4cc4694ca6c328d",
+      "contentId": "b4cc4694ca6c328d"
+    },
+    {
+      "id": "b084080e1fd4de8c",
+      "siteId": "56a14d0750cc844e",
+      "contentId": "b084080e1fd4de8c",
+      "path": "/33cbdf671c7b83b1/edd1e72884bf7d89/046cc19cf0f87d9d/1e241bae572507e8/b084080e1fd4de8c"
+    },
+    {
+      "id": "ac69610ed785849f",
+      "siteId": "dc07b5fb5abd4c35",
+      "contentId": "8d6e2ff3001b9a03",
+      "path": "/84435b45662730da/bd53fa4ef38c1c40/5ea4d48ed6e829a7/ac69610ed785849f"
+    },
+    {
+      "id": "ab2921d83b66edb5",
+      "contentId": "ab2921d83b66edb5"
+    },
+    {
+      "id": "a95b99e0c7614110",
+      "siteId": "dc07b5fb5abd4c35",
+      "contentId": "cd31e0242dedcfa8",
+      "path": "/84435b45662730da/d11017df5d1aaf49/a95b99e0c7614110"
+    },
+    {
+      "id": "a8ede3121df9e2f6",
+      "siteId": "56a14d0750cc844e",
+      "contentId": "a8ede3121df9e2f6",
+      "path": "/587d96465c3c69c4/efab2b0cce535d8a"
+    },
+    {
+      "id": "a6417ce55f02f243",
+      "contentId": "a6417ce55f02f243"
+    },
+    {
+      "id": "a593db912c64b615",
+      "siteId": "dc07b5fb5abd4c35",
+      "contentId": "e7118807488a6364",
+      "path": "/84435b45662730da/bd53fa4ef38c1c40/b85ac625f1ab9db3/a593db912c64b615"
+    },
+    {
+      "id": "a4e3f5b83f51996e",
+      "contentId": "a4e3f5b83f51996e"
+    },
+    {
+      "id": "a21465ccaa9eb97b",
+      "contentId": "a21465ccaa9eb97b"
+    },
+    {
+      "id": "a212a3739b74db01",
+      "siteId": "dc07b5fb5abd4c35",
+      "contentId": "9a601c5b409e510d",
+      "path": "/84435b45662730da/bd53fa4ef38c1c40/410885f6410a0e68/a212a3739b74db01"
+    },
+    {
+      "id": "a06b1df4da698269",
+      "siteId": "696dde5f0b15a227",
+      "contentId": "a06b1df4da698269"
+    },
+    {
+      "id": "9dd6d1b926a6bbc6",
+      "siteId": "dc07b5fb5abd4c35",
+      "contentId": "96657d14578333ce",
+      "path": "/84435b45662730da/d11017df5d1aaf49/9dd6d1b926a6bbc6"
+    },
+    {
+      "id": "9db36de70dd4d157",
+      "siteId": "56a14d0750cc844e",
+      "contentId": "9db36de70dd4d157",
+      "path": "/55d682c23b93bd62"
+    },
+    {
+      "id": "9d0a44c21cfbfae0",
+      "siteId": "dc07b5fb5abd4c35",
+      "contentId": "6b7384cb6c929947",
+      "path": "/6a5898770a646824/9d0a44c21cfbfae0"
+    },
+    {
+      "id": "9a601c5b409e510d",
+      "siteId": "56a14d0750cc844e",
+      "contentId": "9a601c5b409e510d",
+      "path": "/33cbdf671c7b83b1/edd1e72884bf7d89/7516c8021fa03851/ebabde125c44e563"
+    },
+    {
+      "id": "997a69894cd7fb2a",
+      "siteId": "dc07b5fb5abd4c35",
+      "contentId": "e94896f45d8b5699",
+      "path": "/84435b45662730da/bd53fa4ef38c1c40/486f8f791abc7a5f/28387df3419314b8/997a69894cd7fb2a"
+    },
+    {
+      "id": "97c5809a3b2286f0",
+      "siteId": "56a14d0750cc844e",
+      "contentId": "97c5809a3b2286f0",
+      "path": "/33cbdf671c7b83b1/edd1e72884bf7d89/02d09ad2dd7d2332/97c5809a3b2286f0"
+    },
+    {
+      "id": "96657d14578333ce",
+      "siteId": "56a14d0750cc844e",
+      "contentId": "96657d14578333ce",
+      "path": "/33cbdf671c7b83b1/bfc7deb2d5d4425f/3aea139a26edc0e8"
+    },
+    {
+      "id": "93ed03e1af1c242d",
+      "siteId": "dc07b5fb5abd4c35",
+      "contentId": "fa725f0b47fdc408",
+      "path": "/ed043d1606eaf539/93ed03e1af1c242d"
+    },
+    {
+      "id": "8d6e2ff3001b9a03",
+      "siteId": "56a14d0750cc844e",
+      "contentId": "8d6e2ff3001b9a03",
+      "path": "/33cbdf671c7b83b1/edd1e72884bf7d89/c6db14f1d824259c/f81403478cf7d3b5"
+    },
+    {
+      "id": "89494e7dcdff932b",
+      "contentId": "89494e7dcdff932b"
+    },
+    {
+      "id": "8942b689824112e6",
+      "siteId": "56a14d0750cc844e",
+      "contentId": "8942b689824112e6",
+      "path": "/55d682c23b93bd62/b5cfb74078461073"
+    },
+    {
+      "id": "888338d8ca9cb8da",
+      "siteId": "56a14d0750cc844e",
+      "contentId": "888338d8ca9cb8da",
+      "path": "/587d96465c3c69c4/cbdb67762f579cdd"
+    },
+    {
+      "id": "8764987d24e806f3",
+      "contentId": "8764987d24e806f3"
+    },
+    {
+      "id": "86e7f2cb286063a6",
+      "siteId": "dc07b5fb5abd4c35",
+      "contentId": "e8f5370d6569478a",
+      "path": "/84435b45662730da/bd53fa4ef38c1c40/09a152b36247dc0a/86e7f2cb286063a6"
+    },
+    {
+      "id": "8652bdd9640b1c9b",
+      "contentId": "8652bdd9640b1c9b"
+    },
+    {
+      "id": "84435b45662730da",
+      "siteId": "dc07b5fb5abd4c35",
+      "contentId": "f0724ea2d31beeee",
+      "path": "/84435b45662730da"
+    },
+    {
+      "id": "8252c6d5cff8c608",
+      "siteId": "56a14d0750cc844e",
+      "contentId": "8252c6d5cff8c608",
+      "path": "/587d96465c3c69c4/fa725f0b47fdc408/a16aa5b4498271f8"
+    },
+    {
+      "id": "81ebb90e42af884b",
+      "siteId": "dc07b5fb5abd4c35",
+      "contentId": "f5993d6de3609ac0",
+      "path": "/81ebb90e42af884b"
+    },
+    {
+      "id": "7f5d7c4c3879174f",
+      "siteId": "56a14d0750cc844e",
+      "contentId": "7f5d7c4c3879174f",
+      "path": "/33cbdf671c7b83b1/edd1e72884bf7d89/125f0003cf11c725/7f5d7c4c3879174f"
+    },
+    {
+      "id": "7e68ab76a338b481",
+      "siteId": "dc07b5fb5abd4c35",
+      "contentId": "ec9a22125e28ddcc",
+      "path": "/84435b45662730da/bd53fa4ef38c1c40/f16dc0fbeddfaa9f/7e68ab76a338b481"
+    },
+    {
+      "id": "7daec637e1d07ef1",
+      "contentId": "7daec637e1d07ef1"
+    },
+    {
+      "id": "7cdeea74355996a1",
+      "siteId": "dc07b5fb5abd4c35",
+      "contentId": "8252c6d5cff8c608",
+      "path": "/ed043d1606eaf539/93ed03e1af1c242d/7cdeea74355996a1"
+    },
+    {
+      "id": "7c7ec6527e37a00c",
+      "contentId": "7c7ec6527e37a00c"
+    },
+    {
+      "id": "7c793651bfd5b099",
+      "contentId": "7c793651bfd5b099"
+    },
+    {
+      "id": "7bc07003a4e4960a",
+      "siteId": "696dde5f0b15a227",
+      "contentId": "7bc07003a4e4960a"
+    },
+    {
+      "id": "7b2f9815fd86158b",
+      "contentId": "7b2f9815fd86158b"
+    },
+    {
+      "id": "7aa779f9fcf90589",
+      "siteId": "56a14d0750cc844e",
+      "contentId": "7aa779f9fcf90589",
+      "path": "/587d96465c3c69c4/fa725f0b47fdc408/c4d5dd0a42e3f118"
+    },
+    {
+      "id": "7909f54fc49b2b38",
+      "contentId": "7909f54fc49b2b38"
+    },
+    {
+      "id": "78d7aebb7ca0aa3b",
+      "contentId": "78d7aebb7ca0aa3b"
+    },
+    {
+      "id": "78d1e6ccd971faf3",
+      "siteId": "56a14d0750cc844e",
+      "contentId": "78d1e6ccd971faf3",
+      "path": "/33cbdf671c7b83b1/edd1e72884bf7d89/c6db14f1d824259c"
+    },
+    {
+      "id": "75f5feaca1004671",
+      "siteId": "56a14d0750cc844e",
+      "contentId": "75f5feaca1004671",
+      "path": "/33cbdf671c7b83b1/edd1e72884bf7d89/02d09ad2dd7d2332/cfb24ef7ec3a4bc2"
+    },
+    {
+      "id": "7524eb15818546b7",
+      "siteId": "56a14d0750cc844e",
+      "contentId": "7524eb15818546b7",
+      "path": "/587d96465c3c69c4/7a141950d1520c28/50b875b1af055869"
+    },
+    {
+      "id": "749ee4e15707e4ff",
+      "siteId": "56a14d0750cc844e",
+      "contentId": "749ee4e15707e4ff",
+      "path": "/587d96465c3c69c4"
+    },
+    {
+      "id": "71ec0827969c2bd8",
+      "siteId": "696dde5f0b15a227",
+      "contentId": "71ec0827969c2bd8",
+      "path": "/"
+    },
+    {
+      "id": "70f1003260d74f46",
+      "siteId": "56a14d0750cc844e",
+      "contentId": "70f1003260d74f46",
+      "path": "/daa7010ab323b083"
+    },
+    {
+      "id": "70774feb6aba40dc",
+      "siteId": "56a14d0750cc844e",
+      "contentId": "70774feb6aba40dc",
+      "path": "/587d96465c3c69c4/7e48284613344ef2/70774feb6aba40dc"
+    },
+    {
+      "id": "6eff94f91196a7d4",
+      "siteId": "56a14d0750cc844e",
+      "contentId": "6eff94f91196a7d4",
+      "path": "/587d96465c3c69c4/7e48284613344ef2/8767657f952521a1"
+    },
+    {
+      "id": "6c31d6fed5dc2915",
+      "siteId": "dc07b5fb5abd4c35",
+      "contentId": "6eff94f91196a7d4",
+      "path": "/ed043d1606eaf539/2e9f2e07aeab717e/6c31d6fed5dc2915"
+    },
+    {
+      "id": "6b7384cb6c929947",
+      "siteId": "56a14d0750cc844e",
+      "contentId": "6b7384cb6c929947",
+      "path": "/53cdc93aeaeabc4b/6b7384cb6c929947"
+    },
+    {
+      "id": "6a5898770a646824",
+      "siteId": "dc07b5fb5abd4c35",
+      "contentId": "53cdc93aeaeabc4b",
+      "path": "/6a5898770a646824"
+    },
+    {
+      "id": "69a8e80928a60aa4",
+      "siteId": "56a14d0750cc844e",
+      "contentId": "69a8e80928a60aa4",
+      "path": "/587d96465c3c69c4/7e48284613344ef2"
+    },
+    {
+      "id": "67cd8e40499996e0",
+      "contentId": "67cd8e40499996e0"
+    },
+    {
+      "id": "66e88191d1265340",
+      "contentId": "66e88191d1265340"
+    },
+    {
+      "id": "648a0682c458d492",
+      "siteId": "56a14d0750cc844e",
+      "contentId": "28718c1fe9dd5169",
+      "path": "/53cdc93aeaeabc4b/648a0682c458d492"
+    },
+    {
+      "id": "6120bc3f0037c125",
+      "siteId": "dc07b5fb5abd4c35",
+      "contentId": "97c5809a3b2286f0",
+      "path": "/84435b45662730da/bd53fa4ef38c1c40/31f54bc713bc6050/6120bc3f0037c125"
+    },
+    {
+      "id": "60ee30e12429563b",
+      "siteId": "dc07b5fb5abd4c35",
+      "contentId": "fec151165aeb27da",
+      "path": "/84435b45662730da/60ee30e12429563b"
+    },
+    {
+      "id": "5fd98ea58bd33f5f",
+      "siteId": "696dde5f0b15a227",
+      "contentId": "5fd98ea58bd33f5f"
+    },
+    {
+      "id": "5ea4d48ed6e829a7",
+      "siteId": "dc07b5fb5abd4c35",
+      "contentId": "78d1e6ccd971faf3",
+      "path": "/84435b45662730da/bd53fa4ef38c1c40/5ea4d48ed6e829a7"
+    },
+    {
+      "id": "5e4bdb0a09991e19",
+      "siteId": "dc07b5fb5abd4c35",
+      "contentId": "e842f873009bceb2",
+      "path": "/84435b45662730da/bd53fa4ef38c1c40/09a152b36247dc0a/5e4bdb0a09991e19"
+    },
+    {
+      "id": "5c00595a07768f9d",
+      "siteId": "dc07b5fb5abd4c35",
+      "contentId": "0dda554dfe67da45",
+      "path": "/ed043d1606eaf539/5c00595a07768f9d"
+    },
+    {
+      "id": "5bf9b4a48a5031e3",
+      "contentId": "5bf9b4a48a5031e3"
+    },
+    {
+      "id": "5b3756546b7462ba",
+      "siteId": "56a14d0750cc844e",
+      "contentId": "5b3756546b7462ba",
+      "path": "/53cdc93aeaeabc4b/1c2dea326d6cd4bb"
+    },
+    {
+      "id": "59274260f223b65f",
+      "siteId": "56a14d0750cc844e",
+      "contentId": "59274260f223b65f",
+      "path": "/33cbdf671c7b83b1/edd1e72884bf7d89"
+    },
+    {
+      "id": "54de6e5acebb5566",
+      "siteId": "696dde5f0b15a227",
+      "contentId": "54de6e5acebb5566"
+    },
+    {
+      "id": "53cdc93aeaeabc4b",
+      "siteId": "56a14d0750cc844e",
+      "contentId": "53cdc93aeaeabc4b",
+      "path": "/53cdc93aeaeabc4b"
+    },
+    {
+      "id": "52c8212b3ff23e55",
+      "siteId": "56a14d0750cc844e",
+      "contentId": "52c8212b3ff23e55",
+      "path": "/587d96465c3c69c4/cbdb67762f579cdd/80a94c9047967454"
+    },
+    {
+      "id": "52311cd4fb7fce3b",
+      "siteId": "dc07b5fb5abd4c35",
+      "contentId": "0092ff67875b69f8",
+      "path": "/84435b45662730da/bd53fa4ef38c1c40/f16dc0fbeddfaa9f/52311cd4fb7fce3b"
+    },
+    {
+      "id": "518864722dad1deb",
+      "contentId": "518864722dad1deb"
+    },
+    {
+      "id": "4f4d221b9e654c82",
+      "contentId": "4f4d221b9e654c82"
+    },
+    {
+      "id": "4d9d13338d36a696",
+      "siteId": "696dde5f0b15a227",
+      "contentId": "4d9d13338d36a696"
+    },
+    {
+      "id": "4b188044778bdb6e",
+      "siteId": "dc07b5fb5abd4c35",
+      "contentId": "3f4d1ebe4e291e04",
+      "path": "/6a5898770a646824/63a9473a132fba85"
+    },
+    {
+      "id": "4af8d0714f0faad1",
+      "siteId": "dc07b5fb5abd4c35",
+      "contentId": "7f5d7c4c3879174f",
+      "path": "/84435b45662730da/bd53fa4ef38c1c40/b85ac625f1ab9db3/4af8d0714f0faad1"
+    },
+    {
+      "id": "486f8f791abc7a5f",
+      "siteId": "dc07b5fb5abd4c35",
+      "contentId": "046cc19cf0f87d9d",
+      "path": "/84435b45662730da/bd53fa4ef38c1c40/486f8f791abc7a5f"
+    },
+    {
+      "id": "471f4f107fd0d6d2",
+      "contentId": "471f4f107fd0d6d2"
+    },
+    {
+      "id": "437fc8fecb7440f7",
+      "contentId": "437fc8fecb7440f7"
+    },
+    {
+      "id": "41bff0c5d0d381c0",
+      "siteId": "dc07b5fb5abd4c35",
+      "contentId": "888338d8ca9cb8da",
+      "path": "/ed043d1606eaf539/41bff0c5d0d381c0"
+    },
+    {
+      "id": "410885f6410a0e68",
+      "siteId": "dc07b5fb5abd4c35",
+      "contentId": "fb302b23c46fea41",
+      "path": "/84435b45662730da/bd53fa4ef38c1c40/410885f6410a0e68"
+    },
+    {
+      "id": "40fcff128372c95a",
+      "siteId": "dc07b5fb5abd4c35",
+      "contentId": "027be0e907d46d8e",
+      "path": "/84435b45662730da/bd53fa4ef38c1c40/40fcff128372c95a"
+    },
+    {
+      "id": "3fda98a107e6ae1a",
+      "siteId": "dc07b5fb5abd4c35",
+      "contentId": "5b3756546b7462ba",
+      "path": "/6a5898770a646824/3fda98a107e6ae1a"
+    },
+    {
+      "id": "3f4d1ebe4e291e04",
+      "siteId": "56a14d0750cc844e",
+      "contentId": "3f4d1ebe4e291e04",
+      "path": "/53cdc93aeaeabc4b/2230ada40f9189cc"
+    },
+    {
+      "id": "3e782832e1504ecd",
+      "siteId": "dc07b5fb5abd4c35",
+      "contentId": "75f5feaca1004671",
+      "path": "/84435b45662730da/bd53fa4ef38c1c40/31f54bc713bc6050/3e782832e1504ecd"
+    },
+    {
+      "id": "3a4cd2a0a23cea9b",
+      "siteId": "56a14d0750cc844e",
+      "contentId": "3a4cd2a0a23cea9b",
+      "path": "/33cbdf671c7b83b1/bfc7deb2d5d4425f"
+    },
+    {
+      "id": "38d52d38e1f73575",
+      "siteId": "56a14d0750cc844e",
+      "contentId": "38d52d38e1f73575",
+      "path": "/55d682c23b93bd62/c77addb363cd896f"
+    },
+    {
+      "id": "32954debcdfee6a3",
+      "siteId": "56a14d0750cc844e",
+      "contentId": "e57bd020bc65ca3f",
+      "path": "/587d96465c3c69c4/32954debcdfee6a3"
+    },
+    {
+      "id": "31f54bc713bc6050",
+      "siteId": "dc07b5fb5abd4c35",
+      "contentId": "02d09ad2dd7d2332",
+      "path": "/84435b45662730da/bd53fa4ef38c1c40/31f54bc713bc6050"
+    },
+    {
+      "id": "2f5fe2e900e4ce8b",
+      "contentId": "2f5fe2e900e4ce8b"
+    },
+    {
+      "id": "2e9f2e07aeab717e",
+      "siteId": "dc07b5fb5abd4c35",
+      "contentId": "69a8e80928a60aa4",
+      "path": "/ed043d1606eaf539/2e9f2e07aeab717e"
+    },
+    {
+      "id": "2e44384af30acbc8",
+      "siteId": "696dde5f0b15a227",
+      "contentId": "2e44384af30acbc8"
+    },
+    {
+      "id": "2de7f41f5b80e6ab",
+      "contentId": "2de7f41f5b80e6ab"
+    },
+    {
+      "id": "2d2269d9b701ac2d",
+      "contentId": "2d2269d9b701ac2d"
+    },
+    {
+      "id": "2ab32827eeeebef7",
+      "siteId": "56a14d0750cc844e",
+      "contentId": "2ab32827eeeebef7",
+      "path": "/33cbdf671c7b83b1/edd1e72884bf7d89/2ab32827eeeebef7"
+    },
+    {
+      "id": "2a57d2bf1a87afda",
+      "siteId": "56a14d0750cc844e",
+      "contentId": "2a57d2bf1a87afda"
+    },
+    {
+      "id": "2a54d41a981a2ab4",
+      "siteId": "696dde5f0b15a227",
+      "contentId": "2a54d41a981a2ab4"
+    },
+    {
+      "id": "29bd97232006ec75",
+      "contentId": "29bd97232006ec75"
+    },
+    {
+      "id": "29b1bd22ef98b074",
+      "contentId": "29b1bd22ef98b074"
+    },
+    {
+      "id": "29580917605abc9c",
+      "siteId": "dc07b5fb5abd4c35",
+      "contentId": "f909e9691db27360",
+      "path": "/84435b45662730da/bd53fa4ef38c1c40/b85ac625f1ab9db3/29580917605abc9c"
+    },
+    {
+      "id": "28a187fa9ff2d6c2",
+      "siteId": "56a14d0750cc844e",
+      "contentId": "13c793bd134405d4",
+      "path": "/33cbdf671c7b83b1/bfc7deb2d5d4425f/28a187fa9ff2d6c2"
+    },
+    {
+      "id": "28409ab9b03e36b4",
+      "siteId": "56a14d0750cc844e",
+      "contentId": "28409ab9b03e36b4",
+      "path": "/587d96465c3c69c4/cbdb67762f579cdd/b6caaaafc25f0330"
+    },
+    {
+      "id": "28387df3419314b8",
+      "siteId": "dc07b5fb5abd4c35",
+      "contentId": "1e241bae572507e8",
+      "path": "/84435b45662730da/bd53fa4ef38c1c40/486f8f791abc7a5f/28387df3419314b8"
+    },
+    {
+      "id": "281600edb8b95202",
+      "siteId": "dc07b5fb5abd4c35",
+      "contentId": "7aa779f9fcf90589",
+      "path": "/ed043d1606eaf539/93ed03e1af1c242d/281600edb8b95202"
+    },
+    {
+      "id": "26d2c9ef30130477",
+      "siteId": "dc07b5fb5abd4c35",
+      "contentId": "b084080e1fd4de8c",
+      "path": "/84435b45662730da/bd53fa4ef38c1c40/486f8f791abc7a5f/28387df3419314b8/26d2c9ef30130477"
+    },
+    {
+      "id": "2484166e90949b32",
+      "contentId": "2484166e90949b32"
+    },
+    {
+      "id": "22d9c6805af643eb",
+      "contentId": "22d9c6805af643eb"
+    },
+    {
+      "id": "202e29af7f62a739",
+      "siteId": "dc07b5fb5abd4c35",
+      "contentId": "52c8212b3ff23e55",
+      "path": "/ed043d1606eaf539/41bff0c5d0d381c0/202e29af7f62a739"
+    },
+    {
+      "id": "1f6fc8477eeb0862",
+      "contentId": "1f6fc8477eeb0862"
+    },
+    {
+      "id": "1f555d6a877a7662",
+      "siteId": "dc07b5fb5abd4c35",
+      "contentId": "9db36de70dd4d157",
+      "path": "/1f555d6a877a7662"
+    },
+    {
+      "id": "1e241bae572507e8",
+      "siteId": "56a14d0750cc844e",
+      "contentId": "1e241bae572507e8",
+      "path": "/33cbdf671c7b83b1/edd1e72884bf7d89/046cc19cf0f87d9d/1e241bae572507e8"
+    },
+    {
+      "id": "19fa35572ff3975c",
+      "siteId": "696dde5f0b15a227",
+      "contentId": "19fa35572ff3975c"
+    },
+    {
+      "id": "162a0a7e8f6d87d1",
+      "siteId": "56a14d0750cc844e",
+      "contentId": "162a0a7e8f6d87d1",
+      "path": "/587d96465c3c69c4/7e48284613344ef2/162a0a7e8f6d87d1"
+    },
+    {
+      "id": "14c0a6ebac3c6e7b",
+      "contentId": "14c0a6ebac3c6e7b"
+    },
+    {
+      "id": "1481d0454ec9a8eb",
+      "siteId": "696dde5f0b15a227",
+      "contentId": "1481d0454ec9a8eb"
+    },
+    {
+      "id": "140dc93f827a36a4",
+      "siteId": "dc07b5fb5abd4c35",
+      "contentId": "162a0a7e8f6d87d1",
+      "path": "/ed043d1606eaf539/2e9f2e07aeab717e/140dc93f827a36a4"
+    },
+    {
+      "id": "1409db9bede134fb",
+      "contentId": "1409db9bede134fb"
+    },
+    {
+      "id": "13c793bd134405d4",
+      "siteId": "dc07b5fb5abd4c35",
+      "contentId": "13c793bd134405d4",
+      "path": "/84435b45662730da/d11017df5d1aaf49/13c793bd134405d4"
+    },
+    {
+      "id": "125f0003cf11c725",
+      "siteId": "56a14d0750cc844e",
+      "contentId": "125f0003cf11c725",
+      "path": "/33cbdf671c7b83b1/edd1e72884bf7d89/125f0003cf11c725"
+    },
+    {
+      "id": "11a20e6047134560",
+      "contentId": "11a20e6047134560"
+    },
+    {
+      "id": "0e84d1e469f7cfac",
+      "siteId": "56a14d0750cc844e",
+      "contentId": "0e84d1e469f7cfac",
+      "path": "/33cbdf671c7b83b1/edd1e72884bf7d89/4df09188b1541b70"
+    },
+    {
+      "id": "0e0e03ae10d47eee",
+      "siteId": "56a14d0750cc844e",
+      "contentId": "0e0e03ae10d47eee"
+    },
+    {
+      "id": "0dda554dfe67da45",
+      "siteId": "56a14d0750cc844e",
+      "contentId": "0dda554dfe67da45",
+      "path": "/587d96465c3c69c4/7a141950d1520c28"
+    },
+    {
+      "id": "09a152b36247dc0a",
+      "siteId": "dc07b5fb5abd4c35",
+      "contentId": "0e84d1e469f7cfac",
+      "path": "/84435b45662730da/bd53fa4ef38c1c40/09a152b36247dc0a"
+    },
+    {
+      "id": "060918d8e44ae54f",
+      "contentId": "060918d8e44ae54f"
+    },
+    {
+      "id": "0513c02cb152a069",
+      "siteId": "dc07b5fb5abd4c35",
+      "contentId": "fb161c52690aeb71",
+      "path": "/84435b45662730da/bd53fa4ef38c1c40/d54072c39c8ad493/0513c02cb152a069"
+    },
+    {
+      "id": "046cc19cf0f87d9d",
+      "siteId": "56a14d0750cc844e",
+      "contentId": "046cc19cf0f87d9d",
+      "path": "/33cbdf671c7b83b1/edd1e72884bf7d89/046cc19cf0f87d9d"
+    },
+    {
+      "id": "03cd0d7704a1195a",
+      "siteId": "dc07b5fb5abd4c35",
+      "contentId": "7524eb15818546b7",
+      "path": "/ed043d1606eaf539/5c00595a07768f9d/03cd0d7704a1195a"
+    },
+    {
+      "id": "02d09ad2dd7d2332",
+      "siteId": "56a14d0750cc844e",
+      "contentId": "02d09ad2dd7d2332",
+      "path": "/33cbdf671c7b83b1/edd1e72884bf7d89/02d09ad2dd7d2332"
+    },
+    {
+      "id": "027be0e907d46d8e",
+      "siteId": "56a14d0750cc844e",
+      "contentId": "027be0e907d46d8e",
+      "path": "/33cbdf671c7b83b1/edd1e72884bf7d89/027be0e907d46d8e"
+    },
+    {
+      "id": "0092ff67875b69f8",
+      "siteId": "56a14d0750cc844e",
+      "contentId": "0092ff67875b69f8",
+      "path": "/33cbdf671c7b83b1/edd1e72884bf7d89/f7da3de531e46fe9/c8e3f4867be41a12"
+    }
   ]
 }

--- a/src/privateJrPlatform/dumpContent.ts
+++ b/src/privateJrPlatform/dumpContent.ts
@@ -5,10 +5,18 @@ import { loadEnv } from 'vite'
 
 type ObjData = {
   _id: string
+  _content_id?: string
   _path?: string
   _site_id?: string
   _widget_pool?: Record<string, WidgetData>
   pisa_url?: unknown
+}
+
+type ManifestEntry = {
+  id: string
+  siteId?: string
+  contentId?: string
+  path?: string
 }
 type WidgetData = Record<string, unknown>
 type SearchData = { continuation?: string; objs: ObjData[] }
@@ -63,7 +71,7 @@ function fileStats() {
 
 async function dumpContent() {
   let continuation: string | undefined
-  const objIds = []
+  const entries: ManifestEntry[] = []
 
   do {
     const data = (await scrivitoClient.put('workspaces/published/objs/search', {
@@ -87,19 +95,27 @@ async function dumpContent() {
     for (const objData of data.objs) {
       const processedObjData = ignorePerInstanceData(objData)
       await dumpObjAndBinaries(processedObjData)
-      objIds.push(processedObjData._id)
+      entries.push(toManifestEntry(processedObjData))
     }
 
     continuation = data.continuation
   } while (continuation)
 
-  dumpManifest(objIds)
+  dumpManifest(entries)
 }
 
-function dumpManifest(objIds: string[]) {
+function toManifestEntry(objData: ObjData): ManifestEntry {
+  const entry: ManifestEntry = { id: objData._id }
+  if (objData._site_id) entry.siteId = objData._site_id
+  if (objData._content_id) entry.contentId = objData._content_id
+  if (objData._path) entry.path = objData._path
+  return entry
+}
+
+function dumpManifest(objs: ManifestEntry[]) {
   fs.writeFileSync(
     `${DUMP_PATH}/index.json`,
-    JSON.stringify({ objIds }, null, 2),
+    JSON.stringify({ objs }, null, 2),
   )
 }
 


### PR DESCRIPTION
Replaces the legacy `{ objIds: [...] }` manifest with the new `{ objs: [{ id, siteId?, contentId?, path? }] }`. 

Is the target branch correct? Indeed, this highlights the difference between `v6-content`, but it probably needs to be separated. We can create & change the target before merging.

See: https://github.com/infopark/scrivito_js/pull/13002