### PR TITLE
Tailwind: CSS: Convert jr-box-shadow to shadow-portal

### DIFF
--- a/src/Components/DesignAdjustments.tsx
+++ b/src/Components/DesignAdjustments.tsx
@@ -36,7 +36,7 @@ export const DesignAdjustments = connect(
     if (secondary) styles.push(`--color-portal-secondary: ${secondary}`)
 
     const dropShadow = root.get('siteDropShadow')
-    if (!dropShadow) styles.push('--jr-box-shadow: none')
+    if (!dropShadow) styles.push('--shadow-portal: none')
 
     const siteBorderRadius = root.get('siteBorderRadius')
     if (siteBorderRadius) {

--- a/src/assets/stylesheets/index-old.scss
+++ b/src/assets/stylesheets/index-old.scss
@@ -106,7 +106,7 @@
     --radius-portal
   ); // backward compatibility for bs5 components
 
-  --jr-box-shadow: 0 0.375rem 1.5rem 0 rgba(140, 152, 164, 0.25);
+  --shadow-portal: 0 0.375rem 1.5rem 0 rgba(140, 152, 164, 0.25);
   --jr-headline-font-family: 'Firava';
   --jr-headline-font-weight: 500;
 
@@ -779,11 +779,11 @@ header section {
   --bs-card-border-width: 0;
   --bs-card-border-color: rgba(108, 117, 140, 0.15);
   --bs-card-border-radius: var(--radius-portal);
-  --bs-card-box-shadow: var(--jr-box-shadow);
+  --bs-card-box-shadow: var(--shadow-portal);
   --bs-card-inner-border-radius: 0.4375rem;
   --bs-card-cap-bg: transparent;
   --bs-card-bg: transparent;
-  box-shadow: var(--jr-box-shadow);
+  box-shadow: var(--shadow-portal);
 }
 .card,
 .carousel-item {
@@ -1053,7 +1053,7 @@ section:focus >,
   max-width: 100%;
   object-fit: cover;
   border-radius: var(--radius-portal);
-  box-shadow: var(--jr-box-shadow);
+  box-shadow: var(--shadow-portal);
 }
 
 //-- headline with background --//
@@ -1253,7 +1253,7 @@ section.bg-primary {
   padding: 5px 15px;
   background: #fff;
   border-radius: 0 0 var(--radius-portal) var(--radius-portal);
-  box-shadow: var(--jr-box-shadow);
+  box-shadow: var(--shadow-portal);
   align-self: stretch;
   display: flex;
 
@@ -1561,7 +1561,7 @@ header .navbar.navbar-expand-lg {
   line-height: 1;
   color: var(--bs-navbar-color);
   background: #fff;
-  box-shadow: var(--jr-box-shadow);
+  box-shadow: var(--shadow-portal);
 }
 .navbar-toggler .navbar-toggler-toggled {
   display: none;

--- a/src/assets/stylesheets/index.css
+++ b/src/assets/stylesheets/index.css
@@ -11,6 +11,8 @@
 
   --radius-portal: 8.5px;
 
+  --shadow-portal: 0 0.375rem 1.5rem 0 rgba(140, 152, 164, 0.25);
+
   --color-portal-primary: #274486;
   --color-on-portal-primary: best-contrast(
     var(--color-portal-primary),

--- a/src/assets/stylesheets/theme/box-comment.scss
+++ b/src/assets/stylesheets/theme/box-comment.scss
@@ -7,7 +7,7 @@
     img {
       width: 60px;
       border-radius: var(--radius-portal);
-      box-shadow: var(--jr-box-shadow);
+      box-shadow: var(--shadow-portal);
     }
     img[src*='.svg'] {
       padding: 10px;


### PR DESCRIPTION
Future use: `shadow-portal`, e.g. for CardWidget.