### PR TITLE
CardWidget: Don't wrap card-widget-extended in @layer components

### DIFF
--- a/src/Widgets/CardWidget/CardWidgetComponent.css
+++ b/src/Widgets/CardWidget/CardWidgetComponent.css
@@ -1,34 +1,32 @@
 @reference '../../assets/stylesheets/index.css';
 
-@layer components {
-  .card.card-widget-extended {
-    @apply overflow-visible;
-  }
+.card.card-widget-extended {
+  @apply overflow-visible;
+}
 
-  .card-widget-extended::after {
-    @apply content-[''];
-    @apply block;
-    @apply absolute;
-    @apply top-0;
-    @apply bottom-0;
-    @apply -z-[1];
-    @apply bg-inherit;
-    @apply pointer-events-none;
-    @apply rounded-portal;
-  }
+.card-widget-extended::after {
+  @apply content-[''];
+  @apply block;
+  @apply absolute;
+  @apply top-0;
+  @apply bottom-0;
+  @apply -z-[1];
+  @apply bg-inherit;
+  @apply pointer-events-none;
+  @apply rounded-portal;
+}
 
-  *:first-child .card-widget-extended::after {
-    @apply right-0;
-    @apply left-[-2600px];
-  }
+*:first-child .card-widget-extended::after {
+  @apply right-0;
+  @apply left-[-2600px];
+}
 
-  *:last-child .card-widget-extended::after {
-    @apply left-0;
-    @apply right-[-2600px];
-  }
+*:last-child .card-widget-extended::after {
+  @apply left-0;
+  @apply right-[-2600px];
+}
 
-  *:only-child .card-widget-extended::after {
-    @apply left-0;
-    @apply right-0;
-  }
+*:only-child .card-widget-extended::after {
+  @apply left-0;
+  @apply right-0;
 }


### PR DESCRIPTION
The component-imported CSS file is bundled before index.css, so its bare `@layer components {}` became the first layer declaration in the output. Since CSS layer priority follows order of first declaration, this reordered the cascade from `theme, base, components, utilities` to `components, theme, base, utilities`, sinking Tailwind's whole components layer below base. The Preflight reset in base then overrode .card-body/.card-footer, stripping the card's inner padding and making it look different.

Emitting the rules unlayered (like the sibling ImageOrVideo.css) keeps the cascade order intact while @apply still resolves via @reference.

Follow up of https://github.com/Scrivito/scrivito-portal-app/pull/1116.

The result can be seen on the loader and on the mix landing page