### PR TITLE
SmkArtwork: Only return declared attributes

### DIFF
--- a/src/Data/SmkArtwork/SmkArtworkDataClass.ts
+++ b/src/Data/SmkArtwork/SmkArtworkDataClass.ts
@@ -8,21 +8,21 @@ import { ensureObject } from '../../utils/ensureObject'
 import { ensureString } from '../../utils/ensureString'
 
 const attributes = {
-    acquisition_date: ['date', { title: 'Acquisition date' }],
-    creator_date_of_birth: ['date', { title: 'Artist’s date of birth' }],
-    creator_date_of_death: ['date', { title: 'Artist’s date of death' }],
-    creator: ['string', { title: 'Artist' }],
-    current_location_name: ['string', { title: 'Current location' }],
-    frontend_url: ['string', { title: 'URL' }],
-    geo_location: ['string', { title: 'Geo location' }],
-    has_image: ['boolean', { title: 'Has image?' }],
-    image_native: ['string', { title: 'Image URL (high resolution)' }],
-    image_thumbnail: ['string', { title: 'Image URL (thumbnail)' }],
-    label: ['string', { title: 'Label' }],
-    on_display: ['boolean', { title: 'On display?' }],
-    production_date: ['date', { title: 'Creation date' }],
-    public_domain: ['boolean', { title: 'Public domain?' }],
-    title: ['string', { title: 'Title' }],
+  acquisition_date: ['date', { title: 'Acquisition date' }],
+  creator_date_of_birth: ['date', { title: 'Artist’s date of birth' }],
+  creator_date_of_death: ['date', { title: 'Artist’s date of death' }],
+  creator: ['string', { title: 'Artist' }],
+  current_location_name: ['string', { title: 'Current location' }],
+  frontend_url: ['string', { title: 'URL' }],
+  geo_location: ['string', { title: 'Geo location' }],
+  has_image: ['boolean', { title: 'Has image?' }],
+  image_native: ['string', { title: 'Image URL (high resolution)' }],
+  image_thumbnail: ['string', { title: 'Image URL (thumbnail)' }],
+  label: ['string', { title: 'Label' }],
+  on_display: ['boolean', { title: 'On display?' }],
+  production_date: ['date', { title: 'Creation date' }],
+  public_domain: ['boolean', { title: 'Public domain?' }],
+  title: ['string', { title: 'Title' }],
 } as const
 
 export const SmkArtwork = provideDataClass('SmkArtwork', {
@@ -109,7 +109,9 @@ function formatItem(item: Record<string, unknown>) {
   const firstTitle = ensureObject(titles[0])
 
   return {
-    ...item,
+    ...Object.fromEntries(
+      Object.keys(attributes).map((key) => [key, item[key]]),
+    ),
     // Some object numbers contain spaces, therefore we encode it.
     _id: encodeURIComponent(ensureString(item.object_number)),
 

--- a/src/Data/SmkArtwork/SmkArtworkDataClass.ts
+++ b/src/Data/SmkArtwork/SmkArtworkDataClass.ts
@@ -7,9 +7,7 @@ import { ensureArray } from '../../utils/ensureArray'
 import { ensureObject } from '../../utils/ensureObject'
 import { ensureString } from '../../utils/ensureString'
 
-export const SmkArtwork = provideDataClass('SmkArtwork', {
-  title: 'National Gallery of Denmark - Artwork',
-  attributes: {
+const attributes = {
     acquisition_date: ['date', { title: 'Acquisition date' }],
     creator_date_of_birth: ['date', { title: 'Artist’s date of birth' }],
     creator_date_of_death: ['date', { title: 'Artist’s date of death' }],
@@ -25,7 +23,11 @@ export const SmkArtwork = provideDataClass('SmkArtwork', {
     production_date: ['date', { title: 'Creation date' }],
     public_domain: ['boolean', { title: 'Public domain?' }],
     title: ['string', { title: 'Title' }],
-  },
+} as const
+
+export const SmkArtwork = provideDataClass('SmkArtwork', {
+  title: 'National Gallery of Denmark - Artwork',
+  attributes,
   connection: {
     async index(params) {
       // See https://www.smk.dk/en/article/smk-api/ for documentation


### PR DESCRIPTION
### How to reproduce

Prompt in Portal Bot: `show all artworks currently on display`

#### Expected

Bot response is rendered

#### Actual

<img width="502" height="515" alt="image" src="https://github.com/user-attachments/assets/b73776da-68b6-4a00-88c8-c7fd4114a806" />

> API returns 76 fields/item, but system prompt declares only 15 SmkArtwork attrs. formatDataItemDetails spreads ALL customData blindly. 60 undeclared fields = 91% of the payload

Not sure if any users rely on other attributes which are not in the schema.
But Kris is fine with this solution.