### PR TITLE
Fix CheckoutButtonWidget alignment default description

### DIFF
--- a/src/Widgets/CheckoutButtonWidget/CheckoutButtonWidgetEditingConfig.ts
+++ b/src/Widgets/CheckoutButtonWidget/CheckoutButtonWidgetEditingConfig.ts
@@ -9,7 +9,7 @@ provideEditingConfig(CheckoutButtonWidget, {
     successMessage: { title: 'Success Message' },
     alignment: {
       title: 'Alignment',
-      description: 'Default: Left',
+      description: 'Default: Center',
       values: [
         { value: 'left', title: 'Left' },
         { value: 'center', title: 'Center' },


### PR DESCRIPTION
See

```ts
initialContent: {
    alignment: 'center',
```