### PR TITLE
Use etracker instance ID instead of secure code

### DIFF
--- a/src/privateJrPlatform/jrPlatformConfigureEtracker.ts
+++ b/src/privateJrPlatform/jrPlatformConfigureEtracker.ts
@@ -11,10 +11,8 @@ export function jrPlatformConfigureEtracker() {
   if (typeof window === 'undefined') return
   if (isEditorLoggedIn()) return
 
-  const secureCode =
-    getJrPlatformInstanceId() === '8e775f86c0194b4ca7b11bef3f458ee3'
-      ? 'LVKmem'
-      : 'L9bLhx'
+  const jrPlatformInstanceId = getJrPlatformInstanceId()
+  if (!jrPlatformInstanceId) return
 
   const hostnameInstance = instanceFromHostname()
   if (
@@ -33,7 +31,7 @@ export function jrPlatformConfigureEtracker() {
   script.id = '_etLoader'
   script.type = 'text/javascript'
   script.setAttribute('data-block-cookies', 'true')
-  script.setAttribute('data-secure-code', secureCode)
+  script.setAttribute('data-instance-id', jrPlatformInstanceId)
   script.setAttribute('data-page-changed-detection', 'url')
   script.src = 'https://code.etracker.com/code/e.js'
   script.async = true


### PR DESCRIPTION
See internal feature announcement: https://infopark.slack.com/archives/C04TN8LJA/p1784281288382679

For now, I made sure we only track the same list of domains as before.
I left relaxing this and rolling it out to all instances for later, b/c implications may need discussion.

The backend already migrated (linked) the two tracking accounts:
* `LVKmem` (Sales demo) -> `8e775f86c0194b4ca7b11bef3f458ee3`
* `L9bLhx` (Others, including tynacoon.com as the top-tracked no-multi-instance domain) -> `13b78a0a81072f996f5010bb59b48957` (now tynacoon.com only)

FYI the backend will happily ignore instance IDs without a linked tracking account.

CC @fmeies-jr 