### PR TITLE
Enable etracker for all instances

### DIFF
--- a/src/config/configureEtracker.ts
+++ b/src/config/configureEtracker.ts
@@ -6,7 +6,7 @@ declare global {
   }
 }
 
-export function jrPlatformConfigureEtracker() {
+export function configureEtracker() {
   if (typeof window === 'undefined') return
   if (isEditorLoggedIn()) return
 

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -1,5 +1,5 @@
 import { configureErrorReporting } from './configureErrorReporting'
-import { jrPlatformConfigureEtracker } from '../privateJrPlatform/jrPlatformConfigureEtracker'
+import { configureEtracker } from './configureEtracker'
 import { configurePisaSalesQuestionnaireWidgets } from './configurePisaSalesQuestionnaireWidgets'
 import { configureHistory } from './history'
 import { configureObjClassForContentType } from './objClassForContentType'
@@ -16,8 +16,5 @@ export function configure() {
   configureErrorReporting()
   configureWindowScrivito()
   configurePisaSalesQuestionnaireWidgets()
-
-  if (import.meta.env.PRIVATE_JR_PLATFORM) {
-    jrPlatformConfigureEtracker()
-  }
+  configureEtracker()
 }

--- a/src/privateJrPlatform/jrPlatformConfigureEtracker.ts
+++ b/src/privateJrPlatform/jrPlatformConfigureEtracker.ts
@@ -1,5 +1,4 @@
-import { isEditorLoggedIn } from 'scrivito'
-import { getJrPlatformInstanceId, instanceFromHostname } from './multiTenancy'
+import { getInstanceId, isEditorLoggedIn } from 'scrivito'
 
 declare global {
   interface Window {
@@ -11,17 +10,6 @@ export function jrPlatformConfigureEtracker() {
   if (typeof window === 'undefined') return
   if (isEditorLoggedIn()) return
 
-  const jrPlatformInstanceId = getJrPlatformInstanceId()
-  if (!jrPlatformInstanceId) return
-
-  const hostnameInstance = instanceFromHostname()
-  if (
-    hostnameInstance &&
-    hostnameInstance !== '13b78a0a81072f996f5010bb59b48957' // allow tynacoon.com for now
-  ) {
-    return
-  }
-
   // Copyright (c) 2000-2026 etracker GmbH. All rights reserved.
   // No reproduction, publication or modification allowed without permission.
   // etracker code 6.0
@@ -31,7 +19,7 @@ export function jrPlatformConfigureEtracker() {
   script.id = '_etLoader'
   script.type = 'text/javascript'
   script.setAttribute('data-block-cookies', 'true')
-  script.setAttribute('data-instance-id', jrPlatformInstanceId)
+  script.setAttribute('data-instance-id', getInstanceId())
   script.setAttribute('data-page-changed-detection', 'url')
   script.src = 'https://code.etracker.com/code/e.js'
   script.async = true


### PR DESCRIPTION
[Concept GDoc](https://docs.google.com/document/d/1n-CTWSNBskI0uP6-qsnr1kmx2Vr2jySnXu9dWefEEPY)

Removes the instance/hostname allowlist and the JR-Platform-only gate, so etracker now loads for all instances instead of just the pilot one.

FYI the etracker backend mapping for tynacoon.com (`L9bLhx` -> `13b78a0a81072f996f5010bb59b48957`) was set up by Frank on 2026-07-17.