### PR TITLE
Drop deprecated X-XSS-Protection header

### DIFF
--- a/headers.config.ts
+++ b/headers.config.ts
@@ -23,7 +23,6 @@ function headers({
       },
     }),
     'X-Frame-Options': 'sameorigin',
-    'X-XSS-Protection': '1; mode=block',
     'X-Content-Type-Options': 'nosniff',
     'Referrer-Policy': 'strict-origin-when-cross-origin',
   }


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/X-XSS-Protection

(Mentioned in https://infopark.slack.com/archives/C04TN8LHE/p1785942746124229)