### PR TITLE
Send user email address to etracker

### DIFF
--- a/src/config/configureEtracker.ts
+++ b/src/config/configureEtracker.ts
@@ -1,8 +1,10 @@
-import { getInstanceId, isEditorLoggedIn } from 'scrivito'
+import { currentUser, getInstanceId, isEditorLoggedIn, load } from 'scrivito'
 
 declare global {
   interface Window {
     _etr?: { protocol: string }
+    _etracker?: { setUserEmailAddress: (email: string) => void }
+    _etrackerOnReady?: Array<() => void>
   }
 }
 
@@ -25,4 +27,14 @@ export function configureEtracker() {
   script.async = true
 
   document.head.appendChild(script)
+
+  registerUserEmail()
+}
+
+function registerUserEmail() {
+  window._etrackerOnReady = window._etrackerOnReady ?? []
+  window._etrackerOnReady.push(async () => {
+    const email = await load(() => currentUser()?.email())
+    if (email) window._etracker?.setUserEmailAddress(email)
+  })
 }


### PR DESCRIPTION
[Concept Gdoc](https://docs.google.com/document/d/1n-CTWSNBskI0uP6-qsnr1kmx2Vr2jySnXu9dWefEEPY/edit?tab=t.0#heading=h.a5ha7nj8rh3w) (see comments under "User Information")

A working integration can be checked by looking at `window.dataLayer`. There will be an item with the hashed email. The final etracker backend implementation is still WIP.

CC @fmeies-jr 